### PR TITLE
Add 12x recon payload, 1x general payload, and 1x deploy tool for quick redeploy after firmware update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/payloads/library/general/remote_debug_bridge/README.md
+++ b/payloads/library/general/remote_debug_bridge/README.md
@@ -1,0 +1,154 @@
+# Shark Jack Display - Remote Debug Bridge
+
+Turns the Shark Jack into a temporary remote-troubleshooting appliance. Plug it
+into the stranded network, walk to a desk, and reach the gear from a laptop
+instead of from a cold aisle. It pulls an address, opens a **reverse SSH tunnel**
+out to a jump host you control, exposes its own sshd back through that tunnel, and
+**auto-reconnects** if the link blips, all while showing live status on the OLED
+and logging every attempt on-device.
+
+> Born from a three-day production outage debugging isolated Brocade VCS fabric
+> nodes with five people plugged directly into switches in a datacenter. The
+> point of this payload is to never have to do that again: drop it on the
+> segment, and triage from the conference room.
+
+> **Authorized use only.** This opens a remote-access path *into* a network. Run
+> it only on networks you own or are contracted to support, with written
+> authorization, and tear it down when the work is done. Auth is key-only to a
+> jump host you control, with strict host-key checking; nothing is exfiltrated and
+> local logs stay on-device under `/root/loot/debug_bridge/`. See the Legal and
+> Disclaimer sections of the repository README.
+
+## How it works
+
+| Phase | What happens |
+|-------|--------------|
+| **Setup** | preflight: `ssh` present, key present, `JUMP_HOST` configured, jump host key pinned in `KNOWN_HOSTS`. Any miss fails fast with a screen hint |
+| **Network up** | `NETMODE` per `NET_MODE` (DHCP / static / auto), waits for carrier and an IPv4 address, best-effort NTP sync |
+| **Reachability** | pings the jump host (informational; it still tries SSH if ICMP is filtered) and writes the connection summary |
+| **Bridge loop** | a short auth'd command proves egress + key auth and drops an "I'm alive" breadcrumb on the jump host, then opens `ssh -N -R` and holds it. On exit it reconnects (see below) |
+
+## What you connect to
+
+The reverse forward maps a port on the jump host's loopback back to the Shark
+Jack's own sshd:
+
+```
+jump host 127.0.0.1:REMOTE_PORT  ->  Shark Jack 127.0.0.1:22
+```
+
+So from the jump host you run:
+
+```
+ssh -p 2222 root@127.0.0.1
+```
+
+and you land on the **Shark Jack**, which is L2-present on the stranded segment.
+From that shell you reach the switches / fabric (`ssh admin@<switch-mgmt-ip>`,
+set up further local forwards, etc). The Shark Jack is your beachhead; it is not
+forwarding the switches directly.
+
+## One-time setup
+
+**1. Jump host** (a small always-on VM with a public IP). Create an unprivileged
+user for the bridge:
+
+```
+sudo adduser --disabled-password sharkdebug
+```
+
+**2. Keypair on the Shark Jack:**
+
+```
+ssh-keygen -t ed25519 -f /root/.ssh/sharkjack_debug -N ""
+```
+
+**3. Authorize the key on the jump host** (paste `sharkjack_debug.pub` into the
+jump user's `authorized_keys`). Optionally lock the key down to just this tunnel:
+
+```
+restrict,permitlisten="127.0.0.1:2222" ssh-ed25519 AAAA... sharkjack_debug
+```
+
+**4. Pin the jump host's key** on the Shark Jack (required, because the payload
+enforces `StrictHostKeyChecking=yes`):
+
+```
+ssh-keyscan -p 22 <JUMP_HOST> >> /root/.ssh/known_hosts
+```
+
+**5. Edit the CONFIG block** of [`payload.txt`](payload.txt): set at least
+`JUMP_HOST` (and `JUMP_USER` if you changed it). Deploy.
+
+## Output (loot)
+
+`/root/loot/debug_bridge/<UTC-timestamp>_<pid>/`:
+
+```
+summary.txt   <- connection info + how to connect + final status (read this first)
+bridge.log    <- chronological attempt timeline (dials, uptimes, exit codes)
+```
+
+## Auto-reconnect behavior
+
+The loop distinguishes a healthy session from a hard failure:
+
+- A tunnel that stays up at least `STABLE_SECS` is treated as **healthy**. When it
+  later drops, the consecutive-failure counter resets, so a long triage session
+  survives any number of transient blips.
+- Only **consecutive fast failures** (bad key, jump host down, `REMOTE_PORT`
+  already bound) count toward `MAX_RETRIES`, with a backoff that grows on each
+  repeat (capped at 60s). After `MAX_RETRIES` in a row, it gives up and ends red.
+
+## Configuration (top of [`payload.txt`](payload.txt))
+
+| Knob | Default | Notes |
+|------|---------|-------|
+| `JUMP_USER` | `sharkdebug` | unprivileged user on the jump host |
+| `JUMP_HOST` | `X.X.X.X` | **must set**: jump host public IP/DNS. Placeholder fails fast |
+| `JUMP_PORT` | `22` | jump host sshd port |
+| `REMOTE_BIND` | `127.0.0.1` | bind the listener to the jump host loopback (not public) |
+| `REMOTE_PORT` | `2222` | jump-host port that maps back to the Shark Jack |
+| `SSH_KEY` | `/root/.ssh/sharkjack_debug` | private key for the bridge |
+| `KNOWN_HOSTS` | `/root/.ssh/known_hosts` | pinned jump host key |
+| `NET_MODE` | `DHCP_CLIENT` | `STATIC` for a datacenter mgmt drop (fill `STATIC_*`), or `AUTO` |
+| `STATIC_IP` / `STATIC_SUBNET` / `STATIC_GATEWAY` | `192.168.1.*` | used only when `NET_MODE=STATIC` |
+| `DHCP_WAIT_SECS` | `30` | wait for an address before failing |
+| `CONNECT_TIMEOUT` | `10` | per-dial TCP/auth timeout |
+| `MAX_RETRIES` | `15` | give up after this many *consecutive fast* failures |
+| `RETRY_SLEEP` | `10` | base wait between dials (grows on repeats) |
+| `STABLE_SECS` | `60` | a tunnel up this long resets the failure counter |
+| `LOOT_BASE` | `/root/loot/debug_bridge` | where loot lands |
+
+## Requirements
+
+- **`openssh-client` on the Shark Jack.** The options used (`ServerAliveInterval`,
+  `ExitOnForwardFailure`, `UserKnownHostsFile`, etc.) are OpenSSH syntax. If your
+  firmware ships only Dropbear, install it: `opkg update && opkg install
+  openssh-client`.
+- **The Shark Jack's own sshd** listening on `127.0.0.1:22` (this is how you
+  manage the device, so it is normally already running).
+- **A reachable jump host** running sshd with TCP forwarding allowed (the default).
+  Binding to `127.0.0.1` needs no `GatewayPorts`.
+
+## LED / screen cues
+
+`SETUP` -> `SPECIAL` (network up) -> `STAGE1` (jump reachability) -> `STAGE2`
+(dialing) -> `ATTACK` (tunnel up, solid). It cycles `STAGE2`/`ATTACK` across
+reconnects. Red `FAIL` means a preflight failed (no `ssh`, missing key,
+unconfigured `JUMP_HOST`, empty `KNOWN_HOSTS`), no network, or the reconnect
+budget was exhausted. The OLED shows the current dial count, the reverse-forward
+target, and reconnect state.
+
+## Notes / limitations
+
+- **The drop must have egress to the jump host.** The Shark Jack has one port: the
+  network you land on must be able to reach `JUMP_HOST` on `JUMP_PORT` outbound. A
+  fully air-gapped segment cannot form the tunnel.
+- **Pick a free `REMOTE_PORT`.** If it is already bound on the jump host,
+  `ExitOnForwardFailure` makes the tunnel exit immediately (counts as a fast
+  failure). One Shark Jack per `REMOTE_PORT`.
+- **Tear it down.** Pull the device when finished, and remove the key from the
+  jump host's `authorized_keys` at the end of the engagement.
+- **Keep the listener on loopback.** `REMOTE_BIND=127.0.0.1` means the bridge is
+  reachable only by someone already on the jump host, not the public internet.

--- a/payloads/library/general/remote_debug_bridge/payload.txt
+++ b/payloads/library/general/remote_debug_bridge/payload.txt
@@ -66,7 +66,6 @@ LOOT_BASE="/root/loot/debug_bridge"
 # ----------------------------------------------------------------------------
 
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-glow() { LED "$@" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
 # Shared SSH options: key-only, pinned host key, dead-peer detection.
@@ -82,7 +81,7 @@ SSH_OPTS="-i $SSH_KEY -p $JUMP_PORT \
   -o UserKnownHostsFile=$KNOWN_HOSTS"
 
 # ------------------------------ SETUP ---------------------------------------
-glow SETUP
+LED SETUP
 CLEAR_SCREEN 2>/dev/null
 say "Remote Debug Bridge"
 
@@ -92,7 +91,7 @@ REPORT="$RUN/summary.txt"
 LOG="$RUN/bridge.log"
 
 fail() {  # fail <screen msg> <report reason>
-  glow FAIL
+  LED FAIL
   say "$1"
   echo "FAILED: $2" > "$REPORT"
   ALERT "$2" 8 2>/dev/null
@@ -107,7 +106,7 @@ have ssh || fail "ssh missing" "ssh client missing (opkg install openssh-client)
 chmod 600 "$SSH_KEY" 2>/dev/null
 
 # --------------------------- PHASE: NETWORK UP ------------------------------
-glow SPECIAL
+LED SPECIAL
 say "Bringing up eth0 ($NET_MODE)"
 case "$NET_MODE" in
   STATIC) NETMODE STATIC IP_${STATIC_IP} SUBNET_${STATIC_SUBNET} GATEWAY_${STATIC_GATEWAY} 2>/dev/null ;;
@@ -129,7 +128,7 @@ ENABLE_NTP 2>/dev/null               # best-effort clock sync for honest timesta
 say "IP $IP/$PREFIX"
 
 # --------------------------- PHASE: REACHABILITY ----------------------------
-glow STAGE1
+LED STAGE1
 say "Testing jump reachability"
 if ! ping -c 1 -W 3 "$JUMP_HOST" >/dev/null 2>&1; then
   echo "$(date -u 2>/dev/null) ping to $JUMP_HOST failed (ICMP may be filtered); trying SSH anyway" >> "$LOG"
@@ -161,7 +160,7 @@ attempt=0
 fails=0
 while [ "$fails" -lt "$MAX_RETRIES" ]; do
   attempt=$((attempt + 1))
-  glow STAGE2
+  LED STAGE2
   say "Dial $((fails + 1))/$MAX_RETRIES"
 
   STAMP=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)
@@ -180,7 +179,7 @@ while [ "$fails" -lt "$MAX_RETRIES" ]; do
     continue
   fi
 
-  glow ATTACK
+  LED ATTACK
   say "Tunnel up"
   say "$REMOTE_BIND:$REMOTE_PORT"
 
@@ -204,7 +203,7 @@ while [ "$fails" -lt "$MAX_RETRIES" ]; do
 done
 
 # ------------------------------ PHASE: ENDED --------------------------------
-glow FAIL
+LED FAIL
 say "Bridge ended"
 say "$MAX_RETRIES fails"
 {

--- a/payloads/library/general/remote_debug_bridge/payload.txt
+++ b/payloads/library/general/remote_debug_bridge/payload.txt
@@ -5,6 +5,7 @@
 #  Target:      An authorized wired drop you need to reach back into remotely.
 #  Category:    general / remote-access / troubleshooting
 #  Version:     1.1
+#  Firmware:    Tested on Shark Jack Display 1.0.1
 # ----------------------------------------------------------------------------
 #  WHAT IT DOES
 #    Turns the Shark Jack into a temporary remote-troubleshooting appliance, so

--- a/payloads/library/general/remote_debug_bridge/payload.txt
+++ b/payloads/library/general/remote_debug_bridge/payload.txt
@@ -65,7 +65,6 @@ STABLE_SECS=60                  # a tunnel up at least this long counts as healt
 LOOT_BASE="/root/loot/debug_bridge"
 # ----------------------------------------------------------------------------
 
-say()  { SCREEN_WRITE "$*" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
 # Shared SSH options: key-only, pinned host key, dead-peer detection.
@@ -83,7 +82,7 @@ SSH_OPTS="-i $SSH_KEY -p $JUMP_PORT \
 # ------------------------------ SETUP ---------------------------------------
 LED SETUP
 CLEAR_SCREEN 2>/dev/null
-say "Remote Debug Bridge"
+SCREEN_WRITE "Remote Debug Bridge"
 
 RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
 mkdir -p "$RUN"
@@ -92,7 +91,7 @@ LOG="$RUN/bridge.log"
 
 fail() {  # fail <screen msg> <report reason>
   LED FAIL
-  say "$1"
+  SCREEN_WRITE "$1"
   echo "FAILED: $2" > "$REPORT"
   ALERT "$2" 8 2>/dev/null
   exit 1
@@ -107,7 +106,7 @@ chmod 600 "$SSH_KEY" 2>/dev/null
 
 # --------------------------- PHASE: NETWORK UP ------------------------------
 LED SPECIAL
-say "Bringing up eth0 ($NET_MODE)"
+SCREEN_WRITE "Bringing up eth0 ($NET_MODE)"
 case "$NET_MODE" in
   STATIC) NETMODE STATIC IP_${STATIC_IP} SUBNET_${STATIC_SUBNET} GATEWAY_${STATIC_GATEWAY} 2>/dev/null ;;
   AUTO)   NETMODE AUTO 2>/dev/null ;;
@@ -125,11 +124,11 @@ done
 
 GW=$(ip route 2>/dev/null | awk '/default/{print $3; exit}')
 ENABLE_NTP 2>/dev/null               # best-effort clock sync for honest timestamps
-say "IP $IP/$PREFIX"
+SCREEN_WRITE "IP $IP/$PREFIX"
 
 # --------------------------- PHASE: REACHABILITY ----------------------------
 LED STAGE1
-say "Testing jump reachability"
+SCREEN_WRITE "Testing jump reachability"
 if ! ping -c 1 -W 3 "$JUMP_HOST" >/dev/null 2>&1; then
   echo "$(date -u 2>/dev/null) ping to $JUMP_HOST failed (ICMP may be filtered); trying SSH anyway" >> "$LOG"
 fi
@@ -161,7 +160,7 @@ fails=0
 while [ "$fails" -lt "$MAX_RETRIES" ]; do
   attempt=$((attempt + 1))
   LED STAGE2
-  say "Dial $((fails + 1))/$MAX_RETRIES"
+  SCREEN_WRITE "Dial $((fails + 1))/$MAX_RETRIES"
 
   STAMP=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)
   echo "$STAMP attempt $attempt (consecutive fails $fails)" >> "$LOG"
@@ -172,7 +171,7 @@ while [ "$fails" -lt "$MAX_RETRIES" ]; do
         "printf '%s\n' \"shark bridge up from $IP/$PREFIX at $STAMP\" >> ~/sharkjack-bridge.log" \
         >> "$LOG" 2>&1; then
     fails=$((fails + 1))
-    say "Jump unreachable"
+    SCREEN_WRITE "Jump unreachable"
     echo "$STAMP jump host unreachable or auth failed" >> "$LOG"
     back=$((RETRY_SLEEP * fails)); [ "$back" -gt 60 ] && back=60
     sleep "$back"
@@ -180,8 +179,8 @@ while [ "$fails" -lt "$MAX_RETRIES" ]; do
   fi
 
   LED ATTACK
-  say "Tunnel up"
-  say "$REMOTE_BIND:$REMOTE_PORT"
+  SCREEN_WRITE "Tunnel up"
+  SCREEN_WRITE "$REMOTE_BIND:$REMOTE_PORT"
 
   start=$(date +%s 2>/dev/null)
   ssh -N $SSH_OPTS -R "$REMOTE_BIND:$REMOTE_PORT:127.0.0.1:22" "$JUMP_USER@$JUMP_HOST" >> "$LOG" 2>&1
@@ -192,11 +191,11 @@ while [ "$fails" -lt "$MAX_RETRIES" ]; do
 
   if [ "$up" -ge "$STABLE_SECS" ]; then
     fails=0                                   # healthy session; a drop is transient
-    say "Reconnecting"
+    SCREEN_WRITE "Reconnecting"
     sleep "$RETRY_SLEEP"
   else
     fails=$((fails + 1))                      # fast failure; count it, back off
-    say "Drop, retrying"
+    SCREEN_WRITE "Drop, retrying"
     back=$((RETRY_SLEEP * fails)); [ "$back" -gt 60 ] && back=60
     sleep "$back"
   fi
@@ -204,8 +203,8 @@ done
 
 # ------------------------------ PHASE: ENDED --------------------------------
 LED FAIL
-say "Bridge ended"
-say "$MAX_RETRIES fails"
+SCREEN_WRITE "Bridge ended"
+SCREEN_WRITE "$MAX_RETRIES fails"
 {
   echo ""
   echo "---- FINAL STATUS ----------------------------------------"

--- a/payloads/library/general/remote_debug_bridge/payload.txt
+++ b/payloads/library/general/remote_debug_bridge/payload.txt
@@ -1,0 +1,218 @@
+#!/bin/bash
+# ============================================================================
+#  Title:       Remote Debug Bridge (Shark Jack Display)
+#  Author:      Brent Mills
+#  Target:      An authorized wired drop you need to reach back into remotely.
+#  Category:    general / remote-access / troubleshooting
+#  Version:     1.1
+# ----------------------------------------------------------------------------
+#  WHAT IT DOES
+#    Turns the Shark Jack into a temporary remote-troubleshooting appliance, so
+#    you can debug stranded gear from a desk instead of from a cold aisle. It:
+#      - Brings up eth0 (DHCP, or a static datacenter mgmt drop).
+#      - Opens a reverse SSH tunnel to a jump host you control, exposing the
+#        Shark Jack's own sshd back through it.
+#      - Auto-reconnects: a tunnel that was healthy re-dials on a drop; only
+#        repeated fast failures count toward giving up.
+#      - Shows live status on the OLED and logs every attempt on-device.
+#    From the jump host you then:  ssh -p <REMOTE_PORT> root@127.0.0.1
+#    which lands you on the Shark Jack. It is L2-present on the stranded
+#    segment, so you reach the switches/fabric from there.
+#
+#  AUTHORIZATION
+#    This opens a remote-access path INTO a network. Deploy ONLY on networks you
+#    own or are contracted to support, with written authorization, and tear it
+#    down when the work is finished. Auth is key-only to a jump host you control,
+#    with strict host-key checking. Local logs stay on-device under /root/loot.
+#
+#  PREREQUISITES (one-time; see README)
+#    - A keypair at SSH_KEY, its public key in the jump user's authorized_keys.
+#    - The jump host's key pinned in KNOWN_HOSTS (ssh-keyscan), because this
+#      enforces StrictHostKeyChecking=yes.
+#    - openssh-client on the Shark Jack (the options below are OpenSSH syntax).
+# ============================================================================
+
+# ------------------------------- CONFIG -------------------------------------
+# Jump host: a small always-on VM you control. The reverse tunnel lands here.
+JUMP_USER="sharkdebug"
+JUMP_HOST="X.X.X.X"             # cloud VM public IP or DNS. MUST be set.
+JUMP_PORT="22"
+
+# Reverse forward: on the jump host this port maps back to the Shark Jack sshd.
+REMOTE_BIND="127.0.0.1"         # keep the listener local to the jump host
+REMOTE_PORT="2222"              # then, on the jump host: ssh -p 2222 root@127.0.0.1
+
+# Key-only auth and a pinned host key (no passwords, no blind TOFU).
+SSH_KEY="/root/.ssh/sharkjack_debug"
+KNOWN_HOSTS="/root/.ssh/known_hosts"
+
+# Network bring-up. DHCP_CLIENT suits a normal drop; a stranded datacenter mgmt
+# port is often static, so fill STATIC_* and set NET_MODE="STATIC".
+NET_MODE="DHCP_CLIENT"          # DHCP_CLIENT | AUTO | STATIC
+STATIC_IP="192.168.1.250"       # used only when NET_MODE=STATIC
+STATIC_SUBNET="255.255.255.0"   # used only when NET_MODE=STATIC
+STATIC_GATEWAY="192.168.1.1"    # used only when NET_MODE=STATIC
+DHCP_WAIT_SECS=30
+
+# Tunnel behavior.
+CONNECT_TIMEOUT=10              # per-dial TCP/auth timeout
+MAX_RETRIES=15                  # give up after this many CONSECUTIVE fast fails
+RETRY_SLEEP=10                  # base wait between dials (grows on repeat fails)
+STABLE_SECS=60                  # a tunnel up at least this long counts as healthy
+                                # and resets the consecutive-failure counter
+
+LOOT_BASE="/root/loot/debug_bridge"
+# ----------------------------------------------------------------------------
+
+say()  { SCREEN_WRITE "$*" 2>/dev/null; }
+glow() { LED "$@" 2>/dev/null; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Shared SSH options: key-only, pinned host key, dead-peer detection.
+SSH_OPTS="-i $SSH_KEY -p $JUMP_PORT \
+  -o BatchMode=yes \
+  -o IdentitiesOnly=yes \
+  -o PasswordAuthentication=no \
+  -o ConnectTimeout=$CONNECT_TIMEOUT \
+  -o ServerAliveInterval=15 \
+  -o ServerAliveCountMax=2 \
+  -o ExitOnForwardFailure=yes \
+  -o StrictHostKeyChecking=yes \
+  -o UserKnownHostsFile=$KNOWN_HOSTS"
+
+# ------------------------------ SETUP ---------------------------------------
+glow SETUP
+CLEAR_SCREEN 2>/dev/null
+say "Remote Debug Bridge"
+
+RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
+mkdir -p "$RUN"
+REPORT="$RUN/summary.txt"
+LOG="$RUN/bridge.log"
+
+fail() {  # fail <screen msg> <report reason>
+  glow FAIL
+  say "$1"
+  echo "FAILED: $2" > "$REPORT"
+  ALERT "$2" 8 2>/dev/null
+  exit 1
+}
+
+have ssh || fail "ssh missing" "ssh client missing (opkg install openssh-client)"
+[ -f "$SSH_KEY" ] || fail "missing SSH key" "missing SSH key at $SSH_KEY"
+[ "$JUMP_HOST" = "X.X.X.X" ] || [ -z "$JUMP_HOST" ] && fail "set JUMP_HOST" "JUMP_HOST is not configured (still the placeholder)"
+[ -s "$KNOWN_HOSTS" ] || fail "pin host key" "KNOWN_HOSTS empty; pin the jump host: ssh-keyscan -p $JUMP_PORT $JUMP_HOST >> $KNOWN_HOSTS"
+
+chmod 600 "$SSH_KEY" 2>/dev/null
+
+# --------------------------- PHASE: NETWORK UP ------------------------------
+glow SPECIAL
+say "Bringing up eth0 ($NET_MODE)"
+case "$NET_MODE" in
+  STATIC) NETMODE STATIC IP_${STATIC_IP} SUBNET_${STATIC_SUBNET} GATEWAY_${STATIC_GATEWAY} 2>/dev/null ;;
+  AUTO)   NETMODE AUTO 2>/dev/null ;;
+  *)      NETMODE DHCP_CLIENT 2>/dev/null ;;
+esac
+WAIT_FOR_LINK 2>/dev/null            # block until carrier is up (the race fix)
+
+IP=""; PREFIX=""
+for _ in $(seq 1 "$DHCP_WAIT_SECS"); do
+  line=$(ip -o -4 addr show eth0 2>/dev/null | awk '{print $4}' | head -1)
+  if [ -n "$line" ]; then IP=${line%/*}; PREFIX=${line#*/}; break; fi
+  sleep 1
+done
+[ -z "$IP" ] && fail "no network" "no IPv4 on eth0 after ${DHCP_WAIT_SECS}s (NET_MODE=$NET_MODE; NAC/802.1X, no DHCP, or dead drop)"
+
+GW=$(ip route 2>/dev/null | awk '/default/{print $3; exit}')
+ENABLE_NTP 2>/dev/null               # best-effort clock sync for honest timestamps
+say "IP $IP/$PREFIX"
+
+# --------------------------- PHASE: REACHABILITY ----------------------------
+glow STAGE1
+say "Testing jump reachability"
+if ! ping -c 1 -W 3 "$JUMP_HOST" >/dev/null 2>&1; then
+  echo "$(date -u 2>/dev/null) ping to $JUMP_HOST failed (ICMP may be filtered); trying SSH anyway" >> "$LOG"
+fi
+
+{
+  echo "=========================================================="
+  echo " SHARK JACK DISPLAY - REMOTE DEBUG BRIDGE"
+  echo "=========================================================="
+  echo " Run time     : $(date -u '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null)"
+  echo " Local IP     : $IP/$PREFIX   (NET_MODE=$NET_MODE)"
+  echo " Gateway      : ${GW:-unknown}"
+  echo " Jump host    : $JUMP_USER@$JUMP_HOST:$JUMP_PORT"
+  echo " Reverse fwd  : $REMOTE_BIND:$REMOTE_PORT -> Shark Jack 127.0.0.1:22"
+  echo ""
+  echo " From the jump host, connect to the Shark Jack with:"
+  echo "   ssh -p $REMOTE_PORT root@127.0.0.1"
+  echo ""
+  echo " Live attempt timeline is in bridge.log."
+  echo "=========================================================="
+} > "$REPORT"
+
+# --------------------------- PHASE: BRIDGE LOOP -----------------------------
+# Reverse tunnel with resilient reconnect. A tunnel that stays up past
+# STABLE_SECS is "healthy", so a later drop resets the failure counter; only
+# repeated FAST failures (bad key, port in use, jump host down) count toward
+# MAX_RETRIES, with a growing backoff between them.
+attempt=0
+fails=0
+while [ "$fails" -lt "$MAX_RETRIES" ]; do
+  attempt=$((attempt + 1))
+  glow STAGE2
+  say "Dial $((fails + 1))/$MAX_RETRIES"
+
+  STAMP=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)
+  echo "$STAMP attempt $attempt (consecutive fails $fails)" >> "$LOG"
+
+  # Pre-check + breadcrumb: a quick auth'd command proves egress and key auth
+  # before we commit to the blocking tunnel, and leaves an "I'm alive" marker.
+  if ! ssh $SSH_OPTS "$JUMP_USER@$JUMP_HOST" \
+        "printf '%s\n' \"shark bridge up from $IP/$PREFIX at $STAMP\" >> ~/sharkjack-bridge.log" \
+        >> "$LOG" 2>&1; then
+    fails=$((fails + 1))
+    say "Jump unreachable"
+    echo "$STAMP jump host unreachable or auth failed" >> "$LOG"
+    back=$((RETRY_SLEEP * fails)); [ "$back" -gt 60 ] && back=60
+    sleep "$back"
+    continue
+  fi
+
+  glow ATTACK
+  say "Tunnel up"
+  say "$REMOTE_BIND:$REMOTE_PORT"
+
+  start=$(date +%s 2>/dev/null)
+  ssh -N $SSH_OPTS -R "$REMOTE_BIND:$REMOTE_PORT:127.0.0.1:22" "$JUMP_USER@$JUMP_HOST" >> "$LOG" 2>&1
+  rc=$?
+  end=$(date +%s 2>/dev/null)
+  up=$((end - start))
+  echo "$(date -u '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null) tunnel exited rc=$rc after ${up}s" >> "$LOG"
+
+  if [ "$up" -ge "$STABLE_SECS" ]; then
+    fails=0                                   # healthy session; a drop is transient
+    say "Reconnecting"
+    sleep "$RETRY_SLEEP"
+  else
+    fails=$((fails + 1))                      # fast failure; count it, back off
+    say "Drop, retrying"
+    back=$((RETRY_SLEEP * fails)); [ "$back" -gt 60 ] && back=60
+    sleep "$back"
+  fi
+done
+
+# ------------------------------ PHASE: ENDED --------------------------------
+glow FAIL
+say "Bridge ended"
+say "$MAX_RETRIES fails"
+{
+  echo ""
+  echo "---- FINAL STATUS ----------------------------------------"
+  echo " Ended at     : $(date -u '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null)"
+  echo " Dials made   : $attempt"
+  echo " Reason       : $MAX_RETRIES consecutive fast failures (see bridge.log)"
+  echo "=========================================================="
+} >> "$REPORT"
+ALERT "Debug bridge ended after $MAX_RETRIES consecutive failures" 10 2>/dev/null
+exit 0

--- a/payloads/library/recon/dhcp_dns_ad/README.md
+++ b/payloads/library/recon/dhcp_dns_ad/README.md
@@ -1,0 +1,62 @@
+# Shark Jack Display - DHCP + DNS / AD Profiler
+
+Answers "what kind of network is this?" in one pass: it reads the whole DHCP
+offer, finds the Active Directory domain and its domain controllers, attempts a
+zone transfer, checks DNS hygiene, and samples host naming.
+
+> **Authorized use only.** Run only on networks you own or are contracted to
+> assess, within the agreed scope and time window. The AXFR attempt is a
+> standard assessment check; keep it within authorized scope. Nothing is
+> exfiltrated: all output stays on-device under `/root/loot/dhcp_dns_ad/` until
+> you retrieve it.
+
+## What it collects
+
+| Section | How |
+|---------|-----|
+| **DHCP profile** | the whole offer: DNS, domain, NTP, lease time, PXE/TFTP (66/67), WPAD/proxy (252), server-id |
+| **Active Directory** | SRV lookups (`_ldap`/`_kerberos`/`_gc`) to find domain controllers and confirm an AD domain |
+| **Zone transfer** | attempts AXFR against the internal DNS (a classic, reportable misconfiguration) |
+| **DNS hygiene** | open-recursion check on the internal resolver |
+| **Naming sample** | low-noise reverse-PTR sweep (`nmap -sL`, no host probes) to learn host naming |
+
+## Output (loot)
+
+`/root/loot/dhcp_dns_ad/<UTC-timestamp>_<pid>/`:
+
+```
+summary.txt        <- read this first
+dhcp.txt           <- full DHCP discover output
+ad_srv.txt         <- AD SRV enumeration
+axfr.txt           <- zone-transfer attempt
+dns_recursion.txt  ptr_names.txt  vlan_profiles.txt
+```
+
+## Configuration (top of [`payload.txt`](payload.txt))
+
+| Knob | Default | Notes |
+|------|---------|-------|
+| `DHCP_WAIT_SECS` | `30` | how long to wait for a lease before failing |
+| `DOMAIN_OVERRIDE` | `""` | force the AD domain if DHCP does not advertise one |
+| `TRY_ZONE_TRANSFER` | `1` | attempt AXFR against the internal DNS server |
+| `PTR_SWEEP` | `1` | reverse-resolve the local subnet for naming |
+| `SCAN_TAGGED_VLANS` | `1` | **active VLAN-hopping** on a trunk; set `0` for client sites unless explicitly authorized |
+| `VLAN_PROBE_IDS` | `""` | fallback VIDs if none are sniffed, e.g. `"2 3 10"` |
+| `PASSIVE_VLAN_SECS` | `12` | passive 802.1Q listen window (needs `tcpdump`) |
+| `LOOT_BASE` | `/root/loot/dhcp_dns_ad` | where loot lands |
+
+## Requirements
+
+- **`nmap`** (ships on the device). **`tcpdump`** optional, only for passive
+  802.1Q tag sniffing on a trunk.
+
+## LED / screen cues
+
+`SETUP` -> `SPECIAL` (lease) -> `STAGE1` DHCP -> `STAGE2` DNS/AD -> `STAGE3`
+per-VLAN -> `CLEANUP` -> `FINISH`. Red `FAIL` means no DHCP lease (NAC/802.1X,
+no DHCP, or a dead drop).
+
+## Notes
+
+- `SCAN_TAGGED_VLANS=1` is active VLAN-hopping: noisy and intrusive. It no-ops on
+  a plain access port. Leave it `0` unless the engagement authorizes it.

--- a/payloads/library/recon/dhcp_dns_ad/payload.txt
+++ b/payloads/library/recon/dhcp_dns_ad/payload.txt
@@ -5,6 +5,7 @@
 #  Target:      An authorized wired drop, scoping a new environment.
 #  Category:    recon
 #  Version:     1.0
+#  Firmware:    Tested on Shark Jack Display 1.0.1
 # ----------------------------------------------------------------------------
 #  WHAT IT DOES
 #    Answers "what kind of network is this?" in one pass:

--- a/payloads/library/recon/dhcp_dns_ad/payload.txt
+++ b/payloads/library/recon/dhcp_dns_ad/payload.txt
@@ -40,7 +40,6 @@ PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-glow() { LED "$@" 2>/dev/null; }
 spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
@@ -98,10 +97,10 @@ run_over_vlans() {                              # run_over_vlans <cb> <native_ne
 # ----------------------------------------------------------------------------
 
 # ------------------------------ PHASE: SETUP --------------------------------
-glow SETUP
+LED SETUP
 CLEAR_SCREEN 2>/dev/null
 say "DHCP/DNS/AD profiler"
-if ! have nmap; then glow FAIL; say "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
+if ! have nmap; then LED FAIL; say "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
 
 RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
 mkdir -p "$RUN"
@@ -109,7 +108,7 @@ REPORT="$RUN/summary.txt"
 
 
 # --------------------------- PHASE: NETWORK UP ------------------------------
-glow SPECIAL
+LED SPECIAL
 say "DHCP lease (eth0)"
 NETMODE DHCP_CLIENT 2>/dev/null
 WAIT_FOR_LINK 2>/dev/null            # framework: block until carrier is up (the race fix)
@@ -122,7 +121,7 @@ for _ in $(seq 1 "$DHCP_WAIT_SECS"); do
   sleep 1
 done
 if [ -z "$IP" ]; then
-  glow FAIL; say "No lease - 802.1X?"
+  LED FAIL; say "No lease - 802.1X?"
   echo "FAILED: no DHCP lease on eth0 (NAC/802.1X, no DHCP, or dead drop)." > "$REPORT"
   ALERT "No DHCP lease - see loot" 8 2>/dev/null; exit 1
 fi
@@ -131,7 +130,7 @@ say "IP $IP/$PREFIX"
 
 
 # --------------------------- PHASE: DHCP PROFILE ----------------------------
-glow STAGE1
+LED STAGE1
 say "Profiling DHCP"
 spin_up "DHCP discover"
 nmap --script broadcast-dhcp-discover -e eth0 2>/dev/null > "$RUN/dhcp.txt"
@@ -151,7 +150,7 @@ DNS1=$(echo "$DNS" | awk '{print $1}')
 
 
 # --------------------------- PHASE: DNS / AD --------------------------------
-glow STAGE2
+LED STAGE2
 DCS="-"; ZONE="not attempted"; RECUR="-"; PTRN=0
 if [ -n "$DOMAIN" ]; then
   say "AD lookup: $DOMAIN"
@@ -218,14 +217,14 @@ scan_one() {                                    # scan_one <iface> <cidr> <label
   } >> "$RUN/vlan_profiles.txt"
 }
 if [ "$SCAN_TAGGED_VLANS" = "1" ]; then
-  glow STAGE3
+  LED STAGE3
   say "Per-VLAN profiles"
   run_over_vlans scan_one "$(network_cidr "$IP" "$PREFIX")"
 fi
 
 
 # --------------------------- PHASE: WRITE LOOT ------------------------------
-glow CLEANUP
+LED CLEANUP
 say "Writing loot"
 {
   echo "=========================================================="
@@ -267,7 +266,7 @@ say "Writing loot"
 
 
 # ------------------------------ PHASE: DONE ---------------------------------
-glow FINISH
+LED FINISH
 CLEAR_SCREEN 2>/dev/null
 say "Profile complete"
 say "Domain: ${DOMAIN:-none}"

--- a/payloads/library/recon/dhcp_dns_ad/payload.txt
+++ b/payloads/library/recon/dhcp_dns_ad/payload.txt
@@ -1,0 +1,275 @@
+#!/bin/bash
+# ============================================================================
+#  Title:       DHCP + DNS / AD Profiler (Shark Jack Display)
+#  Author:      Brent Mills
+#  Target:      An authorized wired drop, scoping a new environment.
+#  Category:    recon
+#  Version:     1.0
+# ----------------------------------------------------------------------------
+#  WHAT IT DOES
+#    Answers "what kind of network is this?" in one pass:
+#      - DHCP profile ...... the WHOLE offer: DNS, domain, NTP, lease time,
+#                            PXE/TFTP (66/67), WPAD/proxy (252), server-id.
+#      - Active Directory .. SRV lookups (_ldap/_kerberos/_gc) to find domain
+#                            controllers and confirm an AD domain.
+#      - Zone transfer ..... attempts AXFR against the internal DNS (a classic,
+#                            common, reportable misconfiguration).
+#      - DNS hygiene ....... open-recursion check on the internal resolver.
+#      - Naming sample ..... low-noise reverse-PTR sweep to learn host naming.
+#
+#  AUTHORIZATION
+#    Active but benign DNS/DHCP queries against the in-scope network only. The
+#    AXFR attempt is a standard assessment check; keep it within authorized
+#    scope. Output stays on-device in /root/loot until you pull it.
+# ============================================================================
+
+# ------------------------------- CONFIG -------------------------------------
+DHCP_WAIT_SECS=30
+DOMAIN_OVERRIDE=""              # force the AD domain if DHCP doesn't advertise one
+TRY_ZONE_TRANSFER=1            # 1 = attempt AXFR against the internal DNS server
+PTR_SWEEP=1                    # 1 = reverse-resolve the local /24 for naming
+LOOT_BASE="/root/loot/dhcp_dns_ad"
+# VLAN-aware scanning: also tag onto and scan tagged VLANs seen on a trunk.
+SCAN_TAGGED_VLANS=0            # 1 = discover+scan tagged VLANs too. ACTIVE VLAN-
+                              #     hopping; set 0 for client sites unless it is
+                              #     authorized. No-op on a plain access port.
+VLAN_PROBE_IDS=""             # fallback VIDs if none are sniffed, e.g. "2 3 10"
+PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
+# ----------------------------------------------------------------------------
+
+# ============================ helpers =======================================
+say()  { SCREEN_WRITE "$*" 2>/dev/null; }
+glow() { LED "$@" 2>/dev/null; }
+spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
+spin_down() { STOP_SPINNER 2>/dev/null; }
+have() { command -v "$1" >/dev/null 2>&1; }
+field() { grep -iE "$2" "$1" 2>/dev/null | head -1 | sed 's/^[^:]*: *//' | sed 's/^[ \t|]*//; s/[ \t]*$//'; }
+# ============================================================================
+
+
+# ---- VLAN-aware scanning (shared block; keep identical across payloads) -----
+ip_to_int() { local IFS=.; set -- $1; echo $(( ($1<<24)|($2<<16)|($3<<8)|$4 )); }
+int_to_ip() { local i=$1; echo "$(((i>>24)&255)).$(((i>>16)&255)).$(((i>>8)&255)).$((i&255))"; }
+mask_for()  { local p=$1; echo $(( (0xFFFFFFFF << (32-p)) & 0xFFFFFFFF )); }
+network_cidr() { local ip=$1 p=$2 m; m=$(mask_for "$p"); echo "$(int_to_ip $(( $(ip_to_int "$ip") & m )))/$p"; }
+VLAN_SUBNETS=""                                 # "vid:net/prefix ..." for labeling
+vlan_for_ip() {
+  local ip=$1 ipi entry vid cidr net p m; ipi=$(ip_to_int "$ip")
+  for entry in $VLAN_SUBNETS; do
+    vid=${entry%%:*}; cidr=${entry#*:}; net=${cidr%/*}; p=${cidr#*/}; m=$(mask_for "$p")
+    [ $(( ipi & m )) -eq $(( $(ip_to_int "$net") & m )) ] && { echo "vlan$vid"; return; }
+  done
+  echo "access"
+}
+vlan_candidates() {                             # VIDs to scan: sniffed 802.1Q tags, else fallback
+  local tags=""
+  have tcpdump && tags=$(timeout "${PASSIVE_VLAN_SECS}s" tcpdump -e -nn -i eth0 -c 300 vlan 2>/dev/null \
+    | grep -oE 'vlan [0-9]+' | awk '{print $2}' | sort -un | tr '\n' ' ')
+  [ -z "$tags" ] && tags="$VLAN_PROBE_IDS"
+  echo "$tags"
+}
+# Run <cb> over the native VLAN, then (if enabled) each tagged VLAN: bring up
+# eth0.<vid>, DHCP, derive its CIDR, call "<cb> <iface> <cidr> <label>", tear down.
+run_over_vlans() {                              # run_over_vlans <cb> <native_network_cidr>
+  local cb=$1 ncidr=$2 vid vline vcidr vids
+  "$cb" eth0 "$ncidr" access
+  [ "$SCAN_TAGGED_VLANS" = "1" ] || return
+  have ip || return; have udhcpc || return
+  lsmod 2>/dev/null | grep -q 8021q || modprobe 8021q 2>/dev/null
+  vids=$(vlan_candidates)
+  for vid in $vids; do
+    ip link add link eth0 name "eth0.$vid" type vlan id "$vid" 2>/dev/null
+    ip link show "eth0.$vid" >/dev/null 2>&1 || { say "VLAN $vid: no 802.1Q"; continue; }
+    ip link set "eth0.$vid" up 2>/dev/null
+    udhcpc -i "eth0.$vid" -n -q -t 4 -T 3 >/dev/null 2>&1
+    vline=$(ip addr show "eth0.$vid" 2>/dev/null | grep -oE 'inet [0-9.]+/[0-9]+' | head -1 | awk '{print $2}')
+    if [ -n "$vline" ]; then
+      vcidr=$(network_cidr "${vline%/*}" "${vline#*/}")
+      if [ "$vcidr" != "$ncidr" ]; then
+        VLAN_SUBNETS="$VLAN_SUBNETS ${vid}:${vcidr}"
+        "$cb" "eth0.$vid" "$vcidr" "vlan$vid"
+      fi
+    fi
+    ip link set "eth0.$vid" down 2>/dev/null
+    ip link del "eth0.$vid" 2>/dev/null
+  done
+}
+# ----------------------------------------------------------------------------
+
+# ------------------------------ PHASE: SETUP --------------------------------
+glow SETUP
+CLEAR_SCREEN 2>/dev/null
+say "DHCP/DNS/AD profiler"
+if ! have nmap; then glow FAIL; say "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
+
+RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
+mkdir -p "$RUN"
+REPORT="$RUN/summary.txt"
+
+
+# --------------------------- PHASE: NETWORK UP ------------------------------
+glow SPECIAL
+say "DHCP lease (eth0)"
+NETMODE DHCP_CLIENT 2>/dev/null
+WAIT_FOR_LINK 2>/dev/null            # framework: block until carrier is up (the race fix)
+# Bounded lease wait: WAIT_FOR_IP blocks forever, so keep our own timeout to fail
+# cleanly on a NAC'd / no-DHCP drop instead of running blind.
+IP=""; PREFIX=""
+for _ in $(seq 1 "$DHCP_WAIT_SECS"); do
+  line=$(ip -o -4 addr show eth0 2>/dev/null | awk '{print $4}')
+  if [ -n "$line" ]; then IP=${line%/*}; PREFIX=${line#*/}; break; fi
+  sleep 1
+done
+if [ -z "$IP" ]; then
+  glow FAIL; say "No lease - 802.1X?"
+  echo "FAILED: no DHCP lease on eth0 (NAC/802.1X, no DHCP, or dead drop)." > "$REPORT"
+  ALERT "No DHCP lease - see loot" 8 2>/dev/null; exit 1
+fi
+GATEWAY=$(ip route 2>/dev/null | awk '/default/{print $3; exit}')
+say "IP $IP/$PREFIX"
+
+
+# --------------------------- PHASE: DHCP PROFILE ----------------------------
+glow STAGE1
+say "Profiling DHCP"
+spin_up "DHCP discover"
+nmap --script broadcast-dhcp-discover -e eth0 2>/dev/null > "$RUN/dhcp.txt"
+spin_down
+# Prefer DHCP-advertised values; fall back to the resolver config OpenWrt wrote.
+DNS=$(field "$RUN/dhcp.txt" 'Domain Name Server')
+DOMAIN=$(field "$RUN/dhcp.txt" 'Domain Name')
+NTP=$(field "$RUN/dhcp.txt" 'NTP Server')
+LEASE=$(field "$RUN/dhcp.txt" 'Lease Time')
+SRVID=$(field "$RUN/dhcp.txt" 'Server Identifier')
+TFTP=$(field "$RUN/dhcp.txt" 'TFTP|Bootfile|Boot File')
+WPAD=$(field "$RUN/dhcp.txt" 'WPAD|Proxy')
+[ -z "$DNS" ] && DNS=$(grep -h nameserver /tmp/resolv.conf.auto /etc/resolv.conf 2>/dev/null | awk '{print $2}' | sort -u | tr '\n' ' ')
+[ -z "$DOMAIN" ] && DOMAIN=$(grep -hE '^(search|domain)' /tmp/resolv.conf.auto /etc/resolv.conf 2>/dev/null | awk '{print $2}' | head -1)
+[ -n "$DOMAIN_OVERRIDE" ] && DOMAIN="$DOMAIN_OVERRIDE"
+DNS1=$(echo "$DNS" | awk '{print $1}')
+
+
+# --------------------------- PHASE: DNS / AD --------------------------------
+glow STAGE2
+DCS="-"; ZONE="not attempted"; RECUR="-"; PTRN=0
+if [ -n "$DOMAIN" ]; then
+  say "AD lookup: $DOMAIN"
+  spin_up "SRV records ($DOMAIN)"
+  nmap --script dns-srv-enum --script-args "dns-srv-enum.domain=$DOMAIN" 2>/dev/null > "$RUN/ad_srv.txt"
+  spin_down
+  # Domain controllers = unique hosts appearing in the SRV results.
+  DCS=$(grep -oE '[A-Za-z0-9_-]+\.'"$(echo "$DOMAIN" | sed 's/\./\\./g')" "$RUN/ad_srv.txt" 2>/dev/null | sort -u | tr '\n' ' ')
+  [ -z "$DCS" ] && DCS="none found"
+
+  if [ "$TRY_ZONE_TRANSFER" = "1" ] && [ -n "$DNS1" ]; then
+    spin_up "AXFR @ $DNS1"
+    nmap -p53 --script dns-zone-transfer --script-args "dns-zone-transfer.domain=$DOMAIN" "$DNS1" 2>/dev/null > "$RUN/axfr.txt"
+    spin_down
+    if grep -qiE 'Domain Server.*IN|[0-9]+ records|hostname|IN[ \t]+(A|CNAME|MX|NS)' "$RUN/axfr.txt" 2>/dev/null; then
+      ZONE="ALLOWED (transfer succeeded - finding) - see axfr.txt"
+    else
+      ZONE="refused (good)"
+    fi
+  fi
+else
+  say "No domain advertised"
+fi
+
+# DNS open-recursion check on the internal resolver.
+if [ -n "$DNS1" ]; then
+  spin_up "DNS recursion check"
+  nmap -sU -p53 --script dns-recursion "$DNS1" 2>/dev/null > "$RUN/dns_recursion.txt"
+  spin_down
+  if grep -qi 'Recursion appears to be enabled' "$RUN/dns_recursion.txt" 2>/dev/null; then RECUR="enabled"; else RECUR="not detected"; fi
+fi
+
+# Low-noise naming sample: reverse-DNS the /24 (nmap -sL sends no host probes).
+if [ "$PTR_SWEEP" = "1" ]; then
+  spin_up "PTR naming sample"
+  nmap -sL "$IP/$PREFIX" 2>/dev/null | grep 'Nmap scan report for' | grep '(' \
+    | sed 's/Nmap scan report for //' | sort -u > "$RUN/ptr_names.txt"
+  spin_down
+  PTRN=$(wc -l < "$RUN/ptr_names.txt" 2>/dev/null | tr -d ' '); [ -z "$PTRN" ] && PTRN=0
+fi
+
+
+# ----------------------- PHASE: PER-VLAN PROFILE ----------------------------
+# For each tagged VLAN on a trunk: pull its own DHCP offer + reverse-DNS naming.
+# (The native VLAN is profiled above; scan_one skips the "access" label.)
+: > "$RUN/vlan_profiles.txt"
+scan_one() {                                    # scan_one <iface> <cidr> <label>
+  local iface=$1 cidr=$2 label=$3 vsrv vdns vdom
+  [ "$label" = "access" ] && return
+  say "$label: DHCP + naming"
+  nmap --script broadcast-dhcp-discover -e "$iface" 2>/dev/null > "$RUN/dhcp_$label.txt"
+  vsrv=$(field "$RUN/dhcp_$label.txt" 'Server Identifier')
+  vdns=$(field "$RUN/dhcp_$label.txt" 'Domain Name Server')
+  vdom=$(field "$RUN/dhcp_$label.txt" 'Domain Name')
+  { echo " $label  ($cidr)"
+    echo "   DHCP server : ${vsrv:--}"
+    echo "   DNS         : ${vdns:--}"
+    echo "   Domain      : ${vdom:--}"
+    if [ "$PTR_SWEEP" = "1" ]; then
+      echo "   Naming sample:"
+      nmap -sL "$cidr" 2>/dev/null | grep 'Nmap scan report for' | grep '(' \
+        | sed 's/Nmap scan report for //' | sort -u | head -20 | sed 's/^/     /'
+    fi
+  } >> "$RUN/vlan_profiles.txt"
+}
+if [ "$SCAN_TAGGED_VLANS" = "1" ]; then
+  glow STAGE3
+  say "Per-VLAN profiles"
+  run_over_vlans scan_one "$(network_cidr "$IP" "$PREFIX")"
+fi
+
+
+# --------------------------- PHASE: WRITE LOOT ------------------------------
+glow CLEANUP
+say "Writing loot"
+{
+  echo "=========================================================="
+  echo " SHARK JACK DISPLAY - DHCP + DNS / AD PROFILE"
+  echo "=========================================================="
+  echo " Run time : $(date -u '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null)"
+  echo " Our lease: $IP/$PREFIX   Gateway: ${GATEWAY:-unknown}"
+  echo ""
+  echo "---- DHCP PROFILE ----------------------------------------"
+  echo " DHCP server : ${SRVID:-unknown}"
+  echo " DNS server  : ${DNS:--}"
+  echo " Domain      : ${DOMAIN:--}"
+  echo " NTP         : ${NTP:--}"
+  echo " Lease time  : ${LEASE:--}"
+  echo " PXE / TFTP  : ${TFTP:-none advertised}"
+  echo " WPAD/proxy  : ${WPAD:-none advertised}"
+  echo ""
+  echo "---- ACTIVE DIRECTORY ------------------------------------"
+  echo " Domain          : ${DOMAIN:-not advertised}"
+  echo " Domain controllers (from SRV): ${DCS:--}"
+  echo ""
+  echo "---- DNS HYGIENE -----------------------------------------"
+  echo " Zone transfer (AXFR): $ZONE"
+  echo " Open recursion      : $RECUR"
+  echo ""
+  echo "---- NAMING SAMPLE (reverse PTR, $PTRN) ------------------"
+  if [ "$PTRN" -gt 0 ]; then sed 's/^/ /' "$RUN/ptr_names.txt"; else echo " (no PTR records resolved)"; fi
+  echo ""
+  echo "---- PER-VLAN (tagged) -----------------------------------"
+  if [ -s "$RUN/vlan_profiles.txt" ]; then cat "$RUN/vlan_profiles.txt"; else echo " (no tagged VLANs scanned)"; fi
+  echo ""
+  echo "---- RAW ARTIFACTS ---------------------------------------"
+  echo " dhcp.txt        - full DHCP discover output"
+  echo " ad_srv.txt      - AD SRV enumeration"
+  echo " axfr.txt        - zone-transfer attempt"
+  echo " dns_recursion.txt / ptr_names.txt"
+  echo "=========================================================="
+} > "$REPORT"
+
+
+# ------------------------------ PHASE: DONE ---------------------------------
+glow FINISH
+CLEAR_SCREEN 2>/dev/null
+say "Profile complete"
+say "Domain: ${DOMAIN:-none}"
+say "AXFR: $ZONE"
+ALERT "DHCP/DNS/AD done. Domain: ${DOMAIN:-none}. AXFR: $ZONE" 12 2>/dev/null
+exit 0

--- a/payloads/library/recon/dhcp_dns_ad/payload.txt
+++ b/payloads/library/recon/dhcp_dns_ad/payload.txt
@@ -39,7 +39,6 @@ PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
 # ----------------------------------------------------------------------------
 
 # ============================ helpers =======================================
-say()  { SCREEN_WRITE "$*" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 field() { grep -iE "$2" "$1" 2>/dev/null | head -1 | sed 's/^[^:]*: *//' | sed 's/^[ \t|]*//; s/[ \t]*$//'; }
 # ============================================================================
@@ -77,7 +76,7 @@ run_over_vlans() {                              # run_over_vlans <cb> <native_ne
   vids=$(vlan_candidates)
   for vid in $vids; do
     ip link add link eth0 name "eth0.$vid" type vlan id "$vid" 2>/dev/null
-    ip link show "eth0.$vid" >/dev/null 2>&1 || { say "VLAN $vid: no 802.1Q"; continue; }
+    ip link show "eth0.$vid" >/dev/null 2>&1 || { SCREEN_WRITE "VLAN $vid: no 802.1Q"; continue; }
     ip link set "eth0.$vid" up 2>/dev/null
     udhcpc -i "eth0.$vid" -n -q -t 4 -T 3 >/dev/null 2>&1
     vline=$(ip addr show "eth0.$vid" 2>/dev/null | grep -oE 'inet [0-9.]+/[0-9]+' | head -1 | awk '{print $2}')
@@ -97,8 +96,8 @@ run_over_vlans() {                              # run_over_vlans <cb> <native_ne
 # ------------------------------ PHASE: SETUP --------------------------------
 LED SETUP
 CLEAR_SCREEN 2>/dev/null
-say "DHCP/DNS/AD profiler"
-if ! have nmap; then LED FAIL; say "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
+SCREEN_WRITE "DHCP/DNS/AD profiler"
+if ! have nmap; then LED FAIL; SCREEN_WRITE "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
 
 RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
 mkdir -p "$RUN"
@@ -107,7 +106,7 @@ REPORT="$RUN/summary.txt"
 
 # --------------------------- PHASE: NETWORK UP ------------------------------
 LED SPECIAL
-say "DHCP lease (eth0)"
+SCREEN_WRITE "DHCP lease (eth0)"
 NETMODE DHCP_CLIENT 2>/dev/null
 WAIT_FOR_LINK 2>/dev/null            # framework: block until carrier is up (the race fix)
 # Bounded lease wait: WAIT_FOR_IP blocks forever, so keep our own timeout to fail
@@ -119,17 +118,17 @@ for _ in $(seq 1 "$DHCP_WAIT_SECS"); do
   sleep 1
 done
 if [ -z "$IP" ]; then
-  LED FAIL; say "No lease - 802.1X?"
+  LED FAIL; SCREEN_WRITE "No lease - 802.1X?"
   echo "FAILED: no DHCP lease on eth0 (NAC/802.1X, no DHCP, or dead drop)." > "$REPORT"
   ALERT "No DHCP lease - see loot" 8 2>/dev/null; exit 1
 fi
 GATEWAY=$(ip route 2>/dev/null | awk '/default/{print $3; exit}')
-say "IP $IP/$PREFIX"
+SCREEN_WRITE "IP $IP/$PREFIX"
 
 
 # --------------------------- PHASE: DHCP PROFILE ----------------------------
 LED STAGE1
-say "Profiling DHCP"
+SCREEN_WRITE "Profiling DHCP"
 CREATE_SPINNER "DHCP discover"
 nmap --script broadcast-dhcp-discover -e eth0 2>/dev/null > "$RUN/dhcp.txt"
 STOP_SPINNER
@@ -151,7 +150,7 @@ DNS1=$(echo "$DNS" | awk '{print $1}')
 LED STAGE2
 DCS="-"; ZONE="not attempted"; RECUR="-"; PTRN=0
 if [ -n "$DOMAIN" ]; then
-  say "AD lookup: $DOMAIN"
+  SCREEN_WRITE "AD lookup: $DOMAIN"
   CREATE_SPINNER "SRV records ($DOMAIN)"
   nmap --script dns-srv-enum --script-args "dns-srv-enum.domain=$DOMAIN" 2>/dev/null > "$RUN/ad_srv.txt"
   STOP_SPINNER
@@ -170,7 +169,7 @@ if [ -n "$DOMAIN" ]; then
     fi
   fi
 else
-  say "No domain advertised"
+  SCREEN_WRITE "No domain advertised"
 fi
 
 # DNS open-recursion check on the internal resolver.
@@ -198,7 +197,7 @@ fi
 scan_one() {                                    # scan_one <iface> <cidr> <label>
   local iface=$1 cidr=$2 label=$3 vsrv vdns vdom
   [ "$label" = "access" ] && return
-  say "$label: DHCP + naming"
+  SCREEN_WRITE "$label: DHCP + naming"
   nmap --script broadcast-dhcp-discover -e "$iface" 2>/dev/null > "$RUN/dhcp_$label.txt"
   vsrv=$(field "$RUN/dhcp_$label.txt" 'Server Identifier')
   vdns=$(field "$RUN/dhcp_$label.txt" 'Domain Name Server')
@@ -216,14 +215,14 @@ scan_one() {                                    # scan_one <iface> <cidr> <label
 }
 if [ "$SCAN_TAGGED_VLANS" = "1" ]; then
   LED STAGE3
-  say "Per-VLAN profiles"
+  SCREEN_WRITE "Per-VLAN profiles"
   run_over_vlans scan_one "$(network_cidr "$IP" "$PREFIX")"
 fi
 
 
 # --------------------------- PHASE: WRITE LOOT ------------------------------
 LED CLEANUP
-say "Writing loot"
+SCREEN_WRITE "Writing loot"
 {
   echo "=========================================================="
   echo " SHARK JACK DISPLAY - DHCP + DNS / AD PROFILE"
@@ -266,8 +265,8 @@ say "Writing loot"
 # ------------------------------ PHASE: DONE ---------------------------------
 LED FINISH
 CLEAR_SCREEN 2>/dev/null
-say "Profile complete"
-say "Domain: ${DOMAIN:-none}"
-say "AXFR: $ZONE"
+SCREEN_WRITE "Profile complete"
+SCREEN_WRITE "Domain: ${DOMAIN:-none}"
+SCREEN_WRITE "AXFR: $ZONE"
 ALERT "DHCP/DNS/AD done. Domain: ${DOMAIN:-none}. AXFR: $ZONE" 12 2>/dev/null
 exit 0

--- a/payloads/library/recon/dhcp_dns_ad/payload.txt
+++ b/payloads/library/recon/dhcp_dns_ad/payload.txt
@@ -25,12 +25,12 @@
 
 # ------------------------------- CONFIG -------------------------------------
 DHCP_WAIT_SECS=30
-DOMAIN_OVERRIDE=""              # force the AD domain if DHCP doesn't advertise one
-TRY_ZONE_TRANSFER=1            # 1 = attempt AXFR against the internal DNS server
-PTR_SWEEP=1                    # 1 = reverse-resolve the local /24 for naming
+DOMAIN_OVERRIDE=""            # force the AD domain if DHCP doesn't advertise one
+TRY_ZONE_TRANSFER=1           # 1 = attempt AXFR against the internal DNS server
+PTR_SWEEP=1                   # 1 = reverse-resolve the local /24 for naming
 LOOT_BASE="/root/loot/dhcp_dns_ad"
 # VLAN-aware scanning: also tag onto and scan tagged VLANs seen on a trunk.
-SCAN_TAGGED_VLANS=0            # 1 = discover+scan tagged VLANs too. ACTIVE VLAN-
+SCAN_TAGGED_VLANS=0           # 1 = discover+scan tagged VLANs too. ACTIVE VLAN-
                               #     hopping; set 0 for client sites unless it is
                               #     authorized. No-op on a plain access port.
 VLAN_PROBE_IDS=""             # fallback VIDs if none are sniffed, e.g. "2 3 10"

--- a/payloads/library/recon/dhcp_dns_ad/payload.txt
+++ b/payloads/library/recon/dhcp_dns_ad/payload.txt
@@ -40,7 +40,6 @@ PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 field() { grep -iE "$2" "$1" 2>/dev/null | head -1 | sed 's/^[^:]*: *//' | sed 's/^[ \t|]*//; s/[ \t]*$//'; }
 # ============================================================================
@@ -133,7 +132,7 @@ LED STAGE1
 say "Profiling DHCP"
 CREATE_SPINNER "DHCP discover"
 nmap --script broadcast-dhcp-discover -e eth0 2>/dev/null > "$RUN/dhcp.txt"
-spin_down
+STOP_SPINNER
 # Prefer DHCP-advertised values; fall back to the resolver config OpenWrt wrote.
 DNS=$(field "$RUN/dhcp.txt" 'Domain Name Server')
 DOMAIN=$(field "$RUN/dhcp.txt" 'Domain Name')
@@ -155,7 +154,7 @@ if [ -n "$DOMAIN" ]; then
   say "AD lookup: $DOMAIN"
   CREATE_SPINNER "SRV records ($DOMAIN)"
   nmap --script dns-srv-enum --script-args "dns-srv-enum.domain=$DOMAIN" 2>/dev/null > "$RUN/ad_srv.txt"
-  spin_down
+  STOP_SPINNER
   # Domain controllers = unique hosts appearing in the SRV results.
   DCS=$(grep -oE '[A-Za-z0-9_-]+\.'"$(echo "$DOMAIN" | sed 's/\./\\./g')" "$RUN/ad_srv.txt" 2>/dev/null | sort -u | tr '\n' ' ')
   [ -z "$DCS" ] && DCS="none found"
@@ -163,7 +162,7 @@ if [ -n "$DOMAIN" ]; then
   if [ "$TRY_ZONE_TRANSFER" = "1" ] && [ -n "$DNS1" ]; then
     CREATE_SPINNER "AXFR @ $DNS1"
     nmap -p53 --script dns-zone-transfer --script-args "dns-zone-transfer.domain=$DOMAIN" "$DNS1" 2>/dev/null > "$RUN/axfr.txt"
-    spin_down
+    STOP_SPINNER
     if grep -qiE 'Domain Server.*IN|[0-9]+ records|hostname|IN[ \t]+(A|CNAME|MX|NS)' "$RUN/axfr.txt" 2>/dev/null; then
       ZONE="ALLOWED (transfer succeeded - finding) - see axfr.txt"
     else
@@ -178,7 +177,7 @@ fi
 if [ -n "$DNS1" ]; then
   CREATE_SPINNER "DNS recursion check"
   nmap -sU -p53 --script dns-recursion "$DNS1" 2>/dev/null > "$RUN/dns_recursion.txt"
-  spin_down
+  STOP_SPINNER
   if grep -qi 'Recursion appears to be enabled' "$RUN/dns_recursion.txt" 2>/dev/null; then RECUR="enabled"; else RECUR="not detected"; fi
 fi
 
@@ -187,7 +186,7 @@ if [ "$PTR_SWEEP" = "1" ]; then
   CREATE_SPINNER "PTR naming sample"
   nmap -sL "$IP/$PREFIX" 2>/dev/null | grep 'Nmap scan report for' | grep '(' \
     | sed 's/Nmap scan report for //' | sort -u > "$RUN/ptr_names.txt"
-  spin_down
+  STOP_SPINNER
   PTRN=$(wc -l < "$RUN/ptr_names.txt" 2>/dev/null | tr -d ' '); [ -z "$PTRN" ] && PTRN=0
 fi
 

--- a/payloads/library/recon/dhcp_dns_ad/payload.txt
+++ b/payloads/library/recon/dhcp_dns_ad/payload.txt
@@ -40,7 +40,6 @@ PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 field() { grep -iE "$2" "$1" 2>/dev/null | head -1 | sed 's/^[^:]*: *//' | sed 's/^[ \t|]*//; s/[ \t]*$//'; }
@@ -132,7 +131,7 @@ say "IP $IP/$PREFIX"
 # --------------------------- PHASE: DHCP PROFILE ----------------------------
 LED STAGE1
 say "Profiling DHCP"
-spin_up "DHCP discover"
+CREATE_SPINNER "DHCP discover"
 nmap --script broadcast-dhcp-discover -e eth0 2>/dev/null > "$RUN/dhcp.txt"
 spin_down
 # Prefer DHCP-advertised values; fall back to the resolver config OpenWrt wrote.
@@ -154,7 +153,7 @@ LED STAGE2
 DCS="-"; ZONE="not attempted"; RECUR="-"; PTRN=0
 if [ -n "$DOMAIN" ]; then
   say "AD lookup: $DOMAIN"
-  spin_up "SRV records ($DOMAIN)"
+  CREATE_SPINNER "SRV records ($DOMAIN)"
   nmap --script dns-srv-enum --script-args "dns-srv-enum.domain=$DOMAIN" 2>/dev/null > "$RUN/ad_srv.txt"
   spin_down
   # Domain controllers = unique hosts appearing in the SRV results.
@@ -162,7 +161,7 @@ if [ -n "$DOMAIN" ]; then
   [ -z "$DCS" ] && DCS="none found"
 
   if [ "$TRY_ZONE_TRANSFER" = "1" ] && [ -n "$DNS1" ]; then
-    spin_up "AXFR @ $DNS1"
+    CREATE_SPINNER "AXFR @ $DNS1"
     nmap -p53 --script dns-zone-transfer --script-args "dns-zone-transfer.domain=$DOMAIN" "$DNS1" 2>/dev/null > "$RUN/axfr.txt"
     spin_down
     if grep -qiE 'Domain Server.*IN|[0-9]+ records|hostname|IN[ \t]+(A|CNAME|MX|NS)' "$RUN/axfr.txt" 2>/dev/null; then
@@ -177,7 +176,7 @@ fi
 
 # DNS open-recursion check on the internal resolver.
 if [ -n "$DNS1" ]; then
-  spin_up "DNS recursion check"
+  CREATE_SPINNER "DNS recursion check"
   nmap -sU -p53 --script dns-recursion "$DNS1" 2>/dev/null > "$RUN/dns_recursion.txt"
   spin_down
   if grep -qi 'Recursion appears to be enabled' "$RUN/dns_recursion.txt" 2>/dev/null; then RECUR="enabled"; else RECUR="not detected"; fi
@@ -185,7 +184,7 @@ fi
 
 # Low-noise naming sample: reverse-DNS the /24 (nmap -sL sends no host probes).
 if [ "$PTR_SWEEP" = "1" ]; then
-  spin_up "PTR naming sample"
+  CREATE_SPINNER "PTR naming sample"
   nmap -sL "$IP/$PREFIX" 2>/dev/null | grep 'Nmap scan report for' | grep '(' \
     | sed 's/Nmap scan report for //' | sort -u > "$RUN/ptr_names.txt"
   spin_down

--- a/payloads/library/recon/direct_host_profiler/README.md
+++ b/payloads/library/recon/direct_host_profiler/README.md
@@ -1,0 +1,108 @@
+# Shark Jack Display - Direct Host Profiler
+
+Answers one question: **which physical device is HostXYZ?** When something on the
+network is noisy or eating bandwidth but is not bad enough to justify blanket-
+blocking its MAC on the switch, unplug the suspect, cable it straight into the
+Shark Jack, and run this. The device gets a DHCP lease, announces who it is, gets
+scanned, and lands in an identification report, all without ever touching the
+production network.
+
+> **Authorized use only.** Run only on devices you own or are contracted to
+> assess, within the agreed scope and time window. This payload is active only
+> against the single directly-attached device. The Shark Jack serves DHCP on its
+> one Ethernet port and has no uplink, so the device gets an address but no route
+> off the Shark Jack: it is isolated by construction and cannot reach the
+> production network. Nothing is exfiltrated: all output stays on-device under
+> `/root/loot/direct_host/` until you retrieve it. See the Legal and Disclaimer
+> sections of the repository README.
+
+## How it works
+
+| Phase | What happens |
+|-------|--------------|
+| **Link** | brings `eth0` up, waits for carrier, reads speed/duplex |
+| **DHCP server** | starts a passive `tcpdump`, then `NETMODE DHCP_SERVER` (the device's built-in server). No uplink exists, so the client gets an address but no path off the Shark Jack |
+| **Capture** | the passive `tcpdump` runs the whole time, recording the DHCP exchange and any mDNS / NetBIOS / LLMNR the device announces |
+| **Wait for client** | watches the ARP table for the device once it takes the lease (falling back to the assigned IP in the DHCP ACK), then holds the capture open briefly to collect name traffic |
+| **Identify** | pulls the DHCP hostname (Option 12) and vendor-class (Option 60), the client MAC, mDNS `.local` names, and a NetBIOS name via `nmap --script nbstat` |
+| **Scan host** | `nmap -sV -O` against **only** that one leased IP for ports, service/version, and an OS guess |
+| **Report** | fuses every signal into a single device-identification verdict |
+
+The report leads with the headline answer (resolved device name + type), then lists
+every signal it used so you can see *why* it landed there.
+
+## Output (loot)
+
+`/root/loot/direct_host/<UTC-timestamp>_<pid>/`:
+
+```
+summary.txt        <- identity verdict + signals + open ports (read this first)
+passive.pcap       <- full capture (open in Wireshark)
+dhcp_packets.txt   <- decoded DHCP options (hostname, vendor-class, client MAC, Your-IP)
+mdns_raw.txt / mdns_names.txt
+netbios_raw.txt / nbstat.nmap
+llmnr_raw.txt / llmnr_tokens.txt
+services.nmap / services.gnmap / services.xml   <- single-host scan (XML imports)
+```
+
+## Identification signals
+
+It does not trust any single source. The resolved **device name** prefers the
+DHCP Option 12 hostname, then the NetBIOS name, then nmap's rDNS/PTR. The
+**device type** is inferred by fusing the MAC vendor (OUI), the DHCP vendor-class
+(e.g. `MSFT 5.0`, `android-dhcp-13`, `dhcpcd`), any announced names, the OS guess,
+and the open-port fingerprint, so it can call out a printer, camera/NVR, Raspberry
+Pi / SBC, IoT board, Windows / Apple / Linux host, or a mobile device.
+
+## How it serves DHCP
+
+It uses the device's built-in **`NETMODE DHCP_SERVER`**, which serves the unit's
+`config.txt` subnet, rather than bundling its own `udhcpd` (not all firmware
+images ship the `udhcpd` server applet). The isolation that matters here is
+inherent, not configured: the Shark Jack has a single Ethernet port and no
+uplink, so a directly-cabled client receives an address but has no route to the
+internet or to anything else. One device at a time is a consequence of cabling
+one device directly to the port.
+
+## Configuration (top of [`payload.txt`](payload.txt))
+
+| Knob | Default | Notes |
+|------|---------|-------|
+| `LINK_WAIT_SECS` | `20` | wait for carrier before declaring no link |
+| `CLIENT_WAIT_SECS` | `60` | how long to wait for the device to take a lease |
+| `PASSIVE_LISTEN_SECS` | `45` | name-capture window held open after the lease |
+| `PORTSET` | (identity ports) | TCP ports scanned on the one client |
+| `NMAP_TIMING` | `-T4` | `-T3` quieter, `-T5` aggressive |
+| `HOST_TIMEOUT` | `60s` | per-scan budget |
+| `LOOT_BASE` | `/root/loot/direct_host` | where loot lands |
+
+The served subnet comes from the unit's `config.txt` (used by `NETMODE
+DHCP_SERVER`); adjust it there if it collides with the target's expectations.
+
+## Requirements
+
+- **`nmap`** (ships on the device). DHCP is served by the firmware's built-in
+  `NETMODE DHCP_SERVER`, so no separate DHCP daemon is required.
+- **`tcpdump`** recommended: it captures the DHCP hostname, vendor-class, and the
+  mDNS / NetBIOS / LLMNR names. Without it, lease + port-scan still run and naming
+  falls back to nmap alone (`opkg update && opkg install tcpdump`).
+
+## LED / screen cues
+
+`SETUP` -> `SPECIAL` (waiting for link) -> `STAGE1` DHCP server up -> `STAGE2`
+waiting for the client -> `STAGE3` profiling the host -> `CLEANUP` (writing report)
+-> `FINISH`. Red `FAIL` means no link or `nmap` missing. A `LIMITED` result means
+the link came up but no device took a lease. The final `ALERT` carries the
+resolved name and client IP.
+
+## Notes / limitations
+
+- **The device must be a DHCP client.** A statically-addressed host will not take
+  a lease, so the run reports `LIMITED`. That is the common case for a noisy
+  endpoint, but bear it in mind for appliances pinned to a static IP.
+- **One device at a time**, by virtue of cabling a single device to the port.
+- **No internet is offered to the device, on purpose.** It cannot phone home, get
+  blocklisted, or be tipped off mid-profile; it also means cloud-only gadgets may
+  reveal less than they would online.
+- Vendor "Unknown" is usually a stale `nmap-mac-prefixes` table, not a real gap;
+  cross-check the OUI against the DHCP vendor-class and announced names.

--- a/payloads/library/recon/direct_host_profiler/README.md
+++ b/payloads/library/recon/direct_host_profiler/README.md
@@ -13,8 +13,7 @@ production network.
 > one Ethernet port and has no uplink, so the device gets an address but no route
 > off the Shark Jack: it is isolated by construction and cannot reach the
 > production network. Nothing is exfiltrated: all output stays on-device under
-> `/root/loot/direct_host/` until you retrieve it. See the Legal and Disclaimer
-> sections of the repository README.
+> `/root/loot/direct_host/` until you retrieve it.
 
 ## How it works
 

--- a/payloads/library/recon/direct_host_profiler/payload.txt
+++ b/payloads/library/recon/direct_host_profiler/payload.txt
@@ -3,8 +3,9 @@
 #  Title:       Direct Host Profiler (Shark Jack Display)
 #  Author:      Brent Mills
 #  Target:      One unknown device, cabled directly to the Shark Jack.
-#  Category:    admin / device-identification / troubleshooting
+#  Category:    recon / admin / device-identification / troubleshooting
 #  Version:     1.2
+#  Firmware:    Tested on Shark Jack Display 1.0.1
 # ----------------------------------------------------------------------------
 #  WHAT IT DOES
 #    Answers "which physical device is HostXYZ?" when something on the network

--- a/payloads/library/recon/direct_host_profiler/payload.txt
+++ b/payloads/library/recon/direct_host_profiler/payload.txt
@@ -41,7 +41,6 @@ LOOT_BASE="/root/loot/direct_host"
 # ----------------------------------------------------------------------------
 
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-glow() { LED "$@" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
@@ -81,7 +80,7 @@ guess_type() {
 }
 
 # ------------------------------ SETUP ---------------------------------------
-glow SETUP
+LED SETUP
 CLEAR_SCREEN 2>/dev/null
 say "Direct Host Profiler"
 say "Connect target device"
@@ -91,7 +90,7 @@ mkdir -p "$RUN"
 REPORT="$RUN/summary.txt"
 
 if ! have nmap; then
-  glow FAIL
+  LED FAIL
   say "nmap missing"
   echo "FAILED: nmap missing" > "$REPORT"
   ALERT "nmap missing" 8 2>/dev/null
@@ -99,7 +98,7 @@ if ! have nmap; then
 fi
 
 # ------------------------------ LINK ----------------------------------------
-glow SPECIAL
+LED SPECIAL
 ip link set eth0 up 2>/dev/null
 
 LINK="DOWN"
@@ -113,7 +112,7 @@ SPEED=$(get_speed)
 DUPLEX=$(get_duplex)
 
 if [ "$LINK" != "UP" ]; then
-  glow FAIL
+  LED FAIL
   say "Link: DOWN"
   {
     echo "=========================================================="
@@ -130,7 +129,7 @@ fi
 say "Link: ${SPEED:-?} ${DUPLEX:-?}"
 
 # --------------------------- DHCP SERVER ------------------------------------
-glow STAGE1
+LED STAGE1
 say "Starting DHCP server"
 
 # Start the passive capture FIRST so the DHCP handshake (hostname, vendor class,
@@ -159,7 +158,7 @@ done
 [ -z "$SJ_IP" ] && SJ_IP="-"
 
 # --------------------------- WAIT FOR CLIENT --------------------------------
-glow STAGE2
+LED STAGE2
 say "Waiting for client"
 
 CLIENT_IP=""
@@ -194,7 +193,7 @@ if [ -z "$CLIENT_IP" ] && [ -s "$PCAP" ]; then
 fi
 
 if [ -z "$CLIENT_IP" ]; then
-  glow FAIL
+  LED FAIL
   say "No DHCP client"
   {
     echo "=========================================================="
@@ -247,7 +246,7 @@ MDNS_NAMES=$(tr '\n' ' ' < "$RUN/mdns_names.txt" 2>/dev/null)
 [ -z "$CLIENT_MAC" ] && CLIENT_MAC="$DHCP_MAC"
 
 # ------------------------------- SCAN HOST ----------------------------------
-glow STAGE3
+LED STAGE3
 say "Profiling host"
 spin_up "Scanning $CLIENT_IP"
 
@@ -291,7 +290,7 @@ DEVICE_NAME="$DHCP_HOSTNAME"
 DEVICE_TYPE=$(guess_type "$VENDOR $DHCP_VENDOR" "$OS_GUESS" "$DEVICE_NAME $NETBIOS_NAME" "$MDNS_NAMES" "$OPEN_PORT_NUMS")
 
 # ------------------------------- REPORT -------------------------------------
-glow CLEANUP
+LED CLEANUP
 say "Writing report"
 
 {
@@ -347,7 +346,7 @@ say "Writing report"
 } > "$REPORT"
 
 # ------------------------------- DISPLAY ------------------------------------
-glow FINISH
+LED FINISH
 CLEAR_SCREEN 2>/dev/null
 say "Direct Host: DONE"
 say "IP: ${CLIENT_IP:--}"

--- a/payloads/library/recon/direct_host_profiler/payload.txt
+++ b/payloads/library/recon/direct_host_profiler/payload.txt
@@ -1,0 +1,359 @@
+#!/bin/bash
+# ============================================================================
+#  Title:       Direct Host Profiler (Shark Jack Display)
+#  Author:      Brent Mills
+#  Target:      One unknown device, cabled directly to the Shark Jack.
+#  Category:    admin / device-identification / troubleshooting
+#  Version:     1.2
+# ----------------------------------------------------------------------------
+#  WHAT IT DOES
+#    Answers "which physical device is HostXYZ?" when something on the network
+#    is noisy or eating bandwidth but not bad enough to blanket-block its MAC.
+#    Unplug the suspect, plug it straight into the Shark Jack, and:
+#      - Become a DHCP server (the device's built-in NETMODE DHCP_SERVER). The
+#        Shark Jack has no uplink, so the client gets an address but no route
+#        off the device: it is isolated by construction.
+#      - Capture the lease, the DHCP hostname, and the vendor class.
+#      - Harvest mDNS / NetBIOS / LLMNR names the device announces.
+#      - Scan ONLY that one leased client IP for ports / service / OS.
+#      - Fuse it all into a device-identification report.
+#
+#  AUTHORIZATION
+#    Active against the single directly-attached device only: it never touches
+#    the production network (it is its own isolated DHCP island). Run on devices
+#    you own or are contracted to assess. Nothing is exfiltrated: all output
+#    stays on-device in /root/loot until you pull it.
+# ============================================================================
+
+# ------------------------------- CONFIG -------------------------------------
+# DHCP is served by the device's built-in NETMODE DHCP_SERVER (it uses the IP /
+# subnet from the unit's config.txt). There is no separate udhcpd to configure.
+LINK_WAIT_SECS=20               # wait for carrier after the device is cabled
+CLIENT_WAIT_SECS=60             # wait for the device to take a DHCP lease
+PASSIVE_LISTEN_SECS=45          # name-capture window held open after the lease
+
+PORTSET="21,22,23,25,53,80,110,139,143,443,445,515,554,631,3389,5000,5357,5900,8000,8080,8443,9100"
+NMAP_TIMING="-T4"
+HOST_TIMEOUT="60s"
+
+LOOT_BASE="/root/loot/direct_host"
+# ----------------------------------------------------------------------------
+
+say()  { SCREEN_WRITE "$*" 2>/dev/null; }
+glow() { LED "$@" 2>/dev/null; }
+have() { command -v "$1" >/dev/null 2>&1; }
+spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
+spin_down() { STOP_SPINNER 2>/dev/null; }
+
+get_link_state() {
+  cat /sys/class/net/eth0/carrier 2>/dev/null | grep -q 1 && echo "UP" || echo "DOWN"
+}
+
+get_speed() { cat /sys/class/net/eth0/speed 2>/dev/null; }
+get_duplex() { cat /sys/class/net/eth0/duplex 2>/dev/null | tr 'A-Z' 'a-z'; }
+
+guess_type() {
+  local hay ports
+  hay=$(printf '%s %s %s %s' "$1" "$2" "$3" "$4" | tr 'A-Z' 'a-z')
+  ports=",$5,"
+
+  case "$hay" in
+    *raspberr*|*raspbian*) echo "Raspberry Pi / SBC"; return ;;
+    *espressif*|*esp32*|*esp8266*|*tasmota*|*arduino*) echo "IoT / DIY embedded"; return ;;
+    *printer*|*jetdirect*|*laserjet*|*officejet*|*canon*|*epson*|*brother*) echo "Printer / MFP"; return ;;
+    *hikvision*|*dahua*|*axis*|*reolink*|*amcrest*|*camera*|*nvr*) echo "Camera / NVR"; return ;;
+    *iphone*|*ipad*) echo "Apple iOS device"; return ;;
+    *android*) echo "Android / mobile device"; return ;;
+    *windows*|*msft*) echo "Windows host"; return ;;
+    *macos*|*darwin*|*apple*|*macbook*) echo "Apple / macOS host"; return ;;
+    *ubuntu*|*debian*|*linux*|*dhcpcd*|*udhcp*) echo "Linux host"; return ;;
+  esac
+
+  case "$ports" in
+    *,9100,*|*,515,*|*,631,*) echo "Printer / MFP"; return ;;
+    *,554,*) echo "Camera / RTSP device"; return ;;
+    *,445,*|*,3389,*) echo "Windows-like host"; return ;;
+    *,22,*) echo "Linux/Unix-like host"; return ;;
+  esac
+
+  echo "Unknown / verify manually"
+}
+
+# ------------------------------ SETUP ---------------------------------------
+glow SETUP
+CLEAR_SCREEN 2>/dev/null
+say "Direct Host Profiler"
+say "Connect target device"
+
+RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
+mkdir -p "$RUN"
+REPORT="$RUN/summary.txt"
+
+if ! have nmap; then
+  glow FAIL
+  say "nmap missing"
+  echo "FAILED: nmap missing" > "$REPORT"
+  ALERT "nmap missing" 8 2>/dev/null
+  exit 1
+fi
+
+# ------------------------------ LINK ----------------------------------------
+glow SPECIAL
+ip link set eth0 up 2>/dev/null
+
+LINK="DOWN"
+for _ in $(seq 1 "$LINK_WAIT_SECS"); do
+  LINK=$(get_link_state)
+  [ "$LINK" = "UP" ] && break
+  sleep 1
+done
+
+SPEED=$(get_speed)
+DUPLEX=$(get_duplex)
+
+if [ "$LINK" != "UP" ]; then
+  glow FAIL
+  say "Link: DOWN"
+  {
+    echo "=========================================================="
+    echo " SHARK JACK DISPLAY - DIRECT HOST PROFILER"
+    echo "=========================================================="
+    echo " Result : FAIL"
+    echo " Reason : no physical link detected"
+    echo "=========================================================="
+  } > "$REPORT"
+  ALERT "Direct Host: no link" 8 2>/dev/null
+  exit 0
+fi
+
+say "Link: ${SPEED:-?} ${DUPLEX:-?}"
+
+# --------------------------- DHCP SERVER ------------------------------------
+glow STAGE1
+say "Starting DHCP server"
+
+# Start the passive capture FIRST so the DHCP handshake (hostname, vendor class,
+# assigned IP) and any mDNS/NetBIOS/LLMNR land in the pcap.
+PCAP="$RUN/passive.pcap"
+if have tcpdump; then
+  tcpdump -i eth0 -s 0 -w "$PCAP" 2>/dev/null &
+  TCPDUMP_PID=$!
+else
+  TCPDUMP_PID=""
+  echo "tcpdump missing; passive name capture skipped." > "$RUN/passive_skipped.txt"
+fi
+
+# Use the device's built-in DHCP server (serves the unit's config.txt subnet).
+# The Shark Jack has no uplink, so the client gets an address but no route off
+# the device: isolated by construction, no udhcpd/dnsmasq config needed.
+NETMODE DHCP_SERVER 2>/dev/null
+
+# Our server address on eth0, used to exclude ourselves when spotting the client.
+SJ_IP=""
+for _ in $(seq 1 10); do
+  SJ_IP=$(ip -o -4 addr show eth0 2>/dev/null | awk '{print $4}' | head -1 | cut -d/ -f1)
+  [ -n "$SJ_IP" ] && break
+  sleep 1
+done
+[ -z "$SJ_IP" ] && SJ_IP="-"
+
+# --------------------------- WAIT FOR CLIENT --------------------------------
+glow STAGE2
+say "Waiting for client"
+
+CLIENT_IP=""
+CLIENT_MAC=""
+DHCP_HOSTNAME=""
+CLIENT_FOUND=0
+
+# The client ARPs us once it has a lease. On this isolated link the only other
+# neighbor is the target, so the first lladdr entry that is not our own is it.
+# `ip neigh show dev eth0` prints "IP lladdr MAC STATE", so the MAC is field 3.
+for _ in $(seq 1 "$CLIENT_WAIT_SECS"); do
+  CLIENT_IP=$(ip neigh show dev eth0 2>/dev/null | awk -v me="$SJ_IP" '/lladdr/ && $1!=me {print $1; exit}')
+  CLIENT_MAC=$(ip neigh show dev eth0 2>/dev/null | awk -v me="$SJ_IP" '/lladdr/ && $1!=me {print $3; exit}')
+  if [ -n "$CLIENT_IP" ]; then CLIENT_FOUND=1; break; fi
+  sleep 1
+done
+
+# Once a client is on, hold the capture open so noisy name protocols (mDNS,
+# NetBIOS, LLMNR) land in the pcap. No point waiting on a drop that never leased.
+[ "$CLIENT_FOUND" = "1" ] && sleep "$PASSIVE_LISTEN_SECS"
+
+[ -n "$TCPDUMP_PID" ] && kill "$TCPDUMP_PID" 2>/dev/null
+[ -n "$TCPDUMP_PID" ] && wait "$TCPDUMP_PID" 2>/dev/null
+
+# Fallback: if the client never populated the ARP table, recover the address it
+# was assigned straight from the DHCP ACK in the capture.
+if [ -z "$CLIENT_IP" ] && [ -s "$PCAP" ]; then
+  CLIENT_IP=$(tcpdump -nn -vv -r "$PCAP" '(udp port 67 or udp port 68)' 2>/dev/null \
+    | grep -ioE 'Your-IP [0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' \
+    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | grep -v '^0\.0\.0\.0' | head -1)
+  [ -n "$CLIENT_IP" ] && CLIENT_FOUND=1
+fi
+
+if [ -z "$CLIENT_IP" ]; then
+  glow FAIL
+  say "No DHCP client"
+  {
+    echo "=========================================================="
+    echo " SHARK JACK DISPLAY - DIRECT HOST PROFILER"
+    echo "=========================================================="
+    echo " Result : LIMITED"
+    echo " Reason : link up, but no DHCP client appeared"
+    echo " Link   : ${SPEED:-unknown} Mbps ${DUPLEX:-unknown}"
+    echo " Note   : is the target a DHCP client? Statically-addressed"
+    echo "          hosts will not take a lease."
+    echo "=========================================================="
+  } > "$REPORT"
+  ALERT "Direct Host: no DHCP client" 8 2>/dev/null
+  exit 0
+fi
+
+say "Client: $CLIENT_IP"
+
+# --------------------------- DECODE PASSIVE ---------------------------------
+DHCP_VENDOR=""
+DHCP_MAC=""
+if [ -s "$PCAP" ]; then
+  # -vv decodes DHCP options: Hostname (12), Vendor-Class (60), and the client
+  # ethernet address. Far more reliable than scraping strings from the pcap.
+  tcpdump -nn -e -vv -r "$PCAP" '(udp port 67 or udp port 68)' 2>/dev/null > "$RUN/dhcp_packets.txt"
+  tcpdump -nn -A -r "$PCAP" 'udp port 5353' 2>/dev/null > "$RUN/mdns_raw.txt"
+  tcpdump -nn -A -r "$PCAP" 'udp port 137 or udp port 138' 2>/dev/null > "$RUN/netbios_raw.txt"
+  tcpdump -nn -A -r "$PCAP" 'udp port 5355' 2>/dev/null > "$RUN/llmnr_raw.txt"
+
+  DHCP_HOSTNAME=$(grep -i 'Hostname Option' "$RUN/dhcp_packets.txt" 2>/dev/null | head -1 | sed 's/.*Hostname Option[^:]*: *//; s/^"//; s/".*$//')
+  DHCP_VENDOR=$(grep -i 'Option 60' "$RUN/dhcp_packets.txt" 2>/dev/null | head -1 | sed 's/.*Option 60[^:]*: *//; s/^"//; s/".*$//')
+  DHCP_MAC=$(grep -i 'Client-Ethernet-Address' "$RUN/dhcp_packets.txt" 2>/dev/null | head -1 | grep -oiE '([0-9a-f]{2}:){5}[0-9a-f]{2}' | head -1)
+
+  # Fallback only if the option decode came up empty.
+  [ -z "$DHCP_HOSTNAME" ] && DHCP_HOSTNAME=$(strings "$PCAP" 2>/dev/null | grep -E '^[A-Za-z0-9][A-Za-z0-9._-]{1,63}$' | grep -viE '^(Microsoft|MSFT|dhcp|local|arpa)$' | head -1)
+
+  tcpdump -nn -r "$PCAP" 'udp port 5353' 2>/dev/null \
+    | grep -oE '[A-Za-z0-9._-]+\.local' | sort -u > "$RUN/mdns_names.txt"
+
+  tcpdump -nn -r "$PCAP" 'udp port 5355' 2>/dev/null \
+    | grep -oE '[A-Za-z0-9._-]+' | sort -u > "$RUN/llmnr_tokens.txt"
+else
+  : > "$RUN/mdns_names.txt"
+  : > "$RUN/llmnr_tokens.txt"
+fi
+
+MDNS_NAMES=$(tr '\n' ' ' < "$RUN/mdns_names.txt" 2>/dev/null)
+[ -z "$MDNS_NAMES" ] && MDNS_NAMES="-"
+# Prefer the MAC the client put on the wire if ARP/neigh did not give us one.
+[ -z "$CLIENT_MAC" ] && CLIENT_MAC="$DHCP_MAC"
+
+# ------------------------------- SCAN HOST ----------------------------------
+glow STAGE3
+say "Profiling host"
+spin_up "Scanning $CLIENT_IP"
+
+nmap -Pn $NMAP_TIMING --host-timeout "$HOST_TIMEOUT" -sV -O --osscan-guess \
+  --script http-title -p "$PORTSET" "$CLIENT_IP" \
+  -oN "$RUN/services.nmap" -oG "$RUN/services.gnmap" -oX "$RUN/services.xml" \
+  >/dev/null 2>&1
+
+# NetBIOS name service (UDP 137): names a Windows host even when its TCP surface
+# is uninformative, and returns the workgroup/domain. No-op on non-Windows hosts.
+NETBIOS_NAME=""
+nmap -Pn -sU -p137 --script nbstat --host-timeout "$HOST_TIMEOUT" "$CLIENT_IP" \
+  -oN "$RUN/nbstat.nmap" >/dev/null 2>&1
+NETBIOS_NAME=$(grep -i 'NetBIOS name:' "$RUN/nbstat.nmap" 2>/dev/null | head -1 | sed 's/.*NetBIOS name: *//; s/,.*$//')
+[ "$NETBIOS_NAME" = "<unknown>" ] && NETBIOS_NAME=""
+
+spin_down
+
+OPEN_PORTS=$(awk '/^[0-9]+\/tcp[ \t]+open/{split($1,a,"/"); printf "%s/%s ",a[1],$3}' "$RUN/services.nmap" 2>/dev/null)
+OPEN_PORT_NUMS=$(awk '/^[0-9]+\/tcp[ \t]+open/{split($1,a,"/"); printf "%s,",a[1]}' "$RUN/services.nmap" 2>/dev/null | sed 's/,$//')
+HOSTNAME_NMAP=$(awk '/^Nmap scan report for /{
+  line=$0; sub(/^Nmap scan report for /,"",line);
+  if(line ~ /\(.*\)/){sub(/ \(.*/,"",line); print line; exit}
+}' "$RUN/services.nmap" 2>/dev/null)
+
+MAC_LINE=$(grep -m1 '^MAC Address:' "$RUN/services.nmap" 2>/dev/null)
+MAC_NMAP=$(echo "$MAC_LINE" | awk '{print $3}')
+VENDOR=$(echo "$MAC_LINE" | sed 's/^MAC Address: [^ ]* *//; s/[()]//g')
+[ -z "$CLIENT_MAC" ] && CLIENT_MAC="$MAC_NMAP"
+[ -z "$VENDOR" ] && VENDOR="Unknown"
+
+OS_GUESS=$(grep -m1 -E '^OS details:|^Running:|^Aggressive OS guesses:' "$RUN/services.nmap" 2>/dev/null | sed 's/^[^:]*: //')
+[ -z "$OS_GUESS" ] && OS_GUESS="-"
+
+# Name preference: DHCP Option 12, then NetBIOS, then nmap PTR/rDNS.
+DEVICE_NAME="$DHCP_HOSTNAME"
+[ -z "$DEVICE_NAME" ] && DEVICE_NAME="$NETBIOS_NAME"
+[ -z "$DEVICE_NAME" ] && DEVICE_NAME="$HOSTNAME_NMAP"
+[ -z "$DEVICE_NAME" ] && DEVICE_NAME="-"
+
+DEVICE_TYPE=$(guess_type "$VENDOR $DHCP_VENDOR" "$OS_GUESS" "$DEVICE_NAME $NETBIOS_NAME" "$MDNS_NAMES" "$OPEN_PORT_NUMS")
+
+# ------------------------------- REPORT -------------------------------------
+glow CLEANUP
+say "Writing report"
+
+{
+  echo "=========================================================="
+  echo " SHARK JACK DISPLAY - DIRECT HOST PROFILER"
+  echo "=========================================================="
+  echo " Run time : $(date -u '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null)"
+  echo " Loot     : $RUN"
+  echo ""
+  echo "---- RESULT ----------------------------------------------"
+  echo " Status   : COMPLETE"
+  echo " Purpose  : Direct-attached host identification only"
+  echo " Note     : Shark Jack provided DHCP but no routing/NAT."
+  echo ""
+  echo "---- LINK ------------------------------------------------"
+  echo " Link     : $LINK"
+  echo " Speed    : ${SPEED:-unknown} Mbps"
+  echo " Duplex   : ${DUPLEX:-unknown}"
+  echo ""
+  echo "---- TEMPORARY DHCP NETWORK ------------------------------"
+  echo " Server   : NETMODE DHCP_SERVER on eth0"
+  echo " Shark IP : ${SJ_IP:--}"
+  echo " Isolation: Shark Jack has no uplink, so the client has no route off it"
+  echo ""
+  echo "---- CLIENT IDENTITY -------------------------------------"
+  echo " Device name    : ${DEVICE_NAME:--}"
+  echo " Device type    : ${DEVICE_TYPE:--}"
+  echo " IP             : ${CLIENT_IP:--}"
+  echo " MAC            : ${CLIENT_MAC:--}"
+  echo " Vendor (OUI)   : ${VENDOR:--}"
+  echo " DHCP hostname  : ${DHCP_HOSTNAME:--}"
+  echo " DHCP vendor    : ${DHCP_VENDOR:--}"
+  echo " NetBIOS name   : ${NETBIOS_NAME:--}"
+  echo " Nmap hostname  : ${HOSTNAME_NMAP:--}"
+  echo " mDNS names     : ${MDNS_NAMES:--}"
+  echo " OS guess       : ${OS_GUESS:--}"
+  echo ""
+  echo "---- OPEN PORTS ------------------------------------------"
+  if [ -n "$OPEN_PORTS" ]; then
+    awk '/^[0-9]+\/tcp[ \t]+open/{print " " $0}' "$RUN/services.nmap"
+  else
+    echo " No open TCP ports found in configured PORTSET."
+  fi
+  echo ""
+  echo "---- RAW ARTIFACTS ---------------------------------------"
+  echo " passive.pcap"
+  echo " dhcp_packets.txt"
+  echo " mdns_raw.txt / mdns_names.txt"
+  echo " netbios_raw.txt / nbstat.nmap"
+  echo " llmnr_raw.txt / llmnr_tokens.txt"
+  echo " services.nmap / services.gnmap / services.xml"
+  echo "=========================================================="
+} > "$REPORT"
+
+# ------------------------------- DISPLAY ------------------------------------
+glow FINISH
+CLEAR_SCREEN 2>/dev/null
+say "Direct Host: DONE"
+say "IP: ${CLIENT_IP:--}"
+say "MAC: ${CLIENT_MAC:--}"
+say "Name: ${DEVICE_NAME:--}"
+say "Type: ${DEVICE_TYPE:--}"
+say "Ports: ${OPEN_PORTS:-none}"
+
+ALERT "Direct Host done: ${DEVICE_NAME:-unknown} ${CLIENT_IP:-no IP}" 12 2>/dev/null
+exit 0

--- a/payloads/library/recon/direct_host_profiler/payload.txt
+++ b/payloads/library/recon/direct_host_profiler/payload.txt
@@ -42,7 +42,6 @@ LOOT_BASE="/root/loot/direct_host"
 
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
-spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 
 get_link_state() {
@@ -248,7 +247,7 @@ MDNS_NAMES=$(tr '\n' ' ' < "$RUN/mdns_names.txt" 2>/dev/null)
 # ------------------------------- SCAN HOST ----------------------------------
 LED STAGE3
 say "Profiling host"
-spin_up "Scanning $CLIENT_IP"
+CREATE_SPINNER "Scanning $CLIENT_IP"
 
 nmap -Pn $NMAP_TIMING --host-timeout "$HOST_TIMEOUT" -sV -O --osscan-guess \
   --script http-title -p "$PORTSET" "$CLIENT_IP" \

--- a/payloads/library/recon/direct_host_profiler/payload.txt
+++ b/payloads/library/recon/direct_host_profiler/payload.txt
@@ -42,7 +42,6 @@ LOOT_BASE="/root/loot/direct_host"
 
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
-spin_down() { STOP_SPINNER 2>/dev/null; }
 
 get_link_state() {
   cat /sys/class/net/eth0/carrier 2>/dev/null | grep -q 1 && echo "UP" || echo "DOWN"
@@ -262,7 +261,7 @@ nmap -Pn -sU -p137 --script nbstat --host-timeout "$HOST_TIMEOUT" "$CLIENT_IP" \
 NETBIOS_NAME=$(grep -i 'NetBIOS name:' "$RUN/nbstat.nmap" 2>/dev/null | head -1 | sed 's/.*NetBIOS name: *//; s/,.*$//')
 [ "$NETBIOS_NAME" = "<unknown>" ] && NETBIOS_NAME=""
 
-spin_down
+STOP_SPINNER
 
 OPEN_PORTS=$(awk '/^[0-9]+\/tcp[ \t]+open/{split($1,a,"/"); printf "%s/%s ",a[1],$3}' "$RUN/services.nmap" 2>/dev/null)
 OPEN_PORT_NUMS=$(awk '/^[0-9]+\/tcp[ \t]+open/{split($1,a,"/"); printf "%s,",a[1]}' "$RUN/services.nmap" 2>/dev/null | sed 's/,$//')

--- a/payloads/library/recon/direct_host_profiler/payload.txt
+++ b/payloads/library/recon/direct_host_profiler/payload.txt
@@ -40,7 +40,6 @@ HOST_TIMEOUT="60s"
 LOOT_BASE="/root/loot/direct_host"
 # ----------------------------------------------------------------------------
 
-say()  { SCREEN_WRITE "$*" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
 get_link_state() {
@@ -80,8 +79,8 @@ guess_type() {
 # ------------------------------ SETUP ---------------------------------------
 LED SETUP
 CLEAR_SCREEN 2>/dev/null
-say "Direct Host Profiler"
-say "Connect target device"
+SCREEN_WRITE "Direct Host Profiler"
+SCREEN_WRITE "Connect target device"
 
 RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
 mkdir -p "$RUN"
@@ -89,7 +88,7 @@ REPORT="$RUN/summary.txt"
 
 if ! have nmap; then
   LED FAIL
-  say "nmap missing"
+  SCREEN_WRITE "nmap missing"
   echo "FAILED: nmap missing" > "$REPORT"
   ALERT "nmap missing" 8 2>/dev/null
   exit 1
@@ -111,7 +110,7 @@ DUPLEX=$(get_duplex)
 
 if [ "$LINK" != "UP" ]; then
   LED FAIL
-  say "Link: DOWN"
+  SCREEN_WRITE "Link: DOWN"
   {
     echo "=========================================================="
     echo " SHARK JACK DISPLAY - DIRECT HOST PROFILER"
@@ -124,11 +123,11 @@ if [ "$LINK" != "UP" ]; then
   exit 0
 fi
 
-say "Link: ${SPEED:-?} ${DUPLEX:-?}"
+SCREEN_WRITE "Link: ${SPEED:-?} ${DUPLEX:-?}"
 
 # --------------------------- DHCP SERVER ------------------------------------
 LED STAGE1
-say "Starting DHCP server"
+SCREEN_WRITE "Starting DHCP server"
 
 # Start the passive capture FIRST so the DHCP handshake (hostname, vendor class,
 # assigned IP) and any mDNS/NetBIOS/LLMNR land in the pcap.
@@ -157,7 +156,7 @@ done
 
 # --------------------------- WAIT FOR CLIENT --------------------------------
 LED STAGE2
-say "Waiting for client"
+SCREEN_WRITE "Waiting for client"
 
 CLIENT_IP=""
 CLIENT_MAC=""
@@ -192,7 +191,7 @@ fi
 
 if [ -z "$CLIENT_IP" ]; then
   LED FAIL
-  say "No DHCP client"
+  SCREEN_WRITE "No DHCP client"
   {
     echo "=========================================================="
     echo " SHARK JACK DISPLAY - DIRECT HOST PROFILER"
@@ -208,7 +207,7 @@ if [ -z "$CLIENT_IP" ]; then
   exit 0
 fi
 
-say "Client: $CLIENT_IP"
+SCREEN_WRITE "Client: $CLIENT_IP"
 
 # --------------------------- DECODE PASSIVE ---------------------------------
 DHCP_VENDOR=""
@@ -245,7 +244,7 @@ MDNS_NAMES=$(tr '\n' ' ' < "$RUN/mdns_names.txt" 2>/dev/null)
 
 # ------------------------------- SCAN HOST ----------------------------------
 LED STAGE3
-say "Profiling host"
+SCREEN_WRITE "Profiling host"
 CREATE_SPINNER "Scanning $CLIENT_IP"
 
 nmap -Pn $NMAP_TIMING --host-timeout "$HOST_TIMEOUT" -sV -O --osscan-guess \
@@ -289,7 +288,7 @@ DEVICE_TYPE=$(guess_type "$VENDOR $DHCP_VENDOR" "$OS_GUESS" "$DEVICE_NAME $NETBI
 
 # ------------------------------- REPORT -------------------------------------
 LED CLEANUP
-say "Writing report"
+SCREEN_WRITE "Writing report"
 
 {
   echo "=========================================================="
@@ -346,12 +345,12 @@ say "Writing report"
 # ------------------------------- DISPLAY ------------------------------------
 LED FINISH
 CLEAR_SCREEN 2>/dev/null
-say "Direct Host: DONE"
-say "IP: ${CLIENT_IP:--}"
-say "MAC: ${CLIENT_MAC:--}"
-say "Name: ${DEVICE_NAME:--}"
-say "Type: ${DEVICE_TYPE:--}"
-say "Ports: ${OPEN_PORTS:-none}"
+SCREEN_WRITE "Direct Host: DONE"
+SCREEN_WRITE "IP: ${CLIENT_IP:--}"
+SCREEN_WRITE "MAC: ${CLIENT_MAC:--}"
+SCREEN_WRITE "Name: ${DEVICE_NAME:--}"
+SCREEN_WRITE "Type: ${DEVICE_TYPE:--}"
+SCREEN_WRITE "Ports: ${OPEN_PORTS:-none}"
 
 ALERT "Direct Host done: ${DEVICE_NAME:-unknown} ${CLIENT_IP:-no IP}" 12 2>/dev/null
 exit 0

--- a/payloads/library/recon/full_recon/README.md
+++ b/payloads/library/recon/full_recon/README.md
@@ -1,0 +1,107 @@
+# Shark Jack Display - Wired Recon + Loot
+
+A plug-and-walk-away wired reconnaissance payload for the Hak5 **Shark Jack
+Display**. Drop it into an RJ45 port on an authorized network, give it a few
+minutes, and pull a tidy loot report off the device.
+
+This is a working tool for
+> *authorized* network recon during tech-consulting engagements (office and
+> datacenter walk-throughs, HID/AV/IoT debugging, inventory sanity checks).
+> Treat it like any active scanner: in scope, in writing, in the time window.
+
+## What it collects
+
+| # | Goal | How |
+|---|------|-----|
+| 1 | **Router / gateway**: hostname, IP, MAC, vendor, OS + version | default route -> `nmap -O -sV` on the gateway |
+| 2 | **VLANs / subnets**: VLAN ID + CIDR | access subnet from our lease (always); passive 802.1Q tag sniff on a trunk; optional active scan of each tagged VLAN (folds its hosts into the report, labeled by VLAN) |
+| 3 | **Hosts**: hostname, IP, MAC, vendor, VLAN/subnet | `nmap -sn` ARP/ping sweep of the access subnet |
+| 4 | **Open ports** per host: port/proto + service/version | `nmap -sV --top-ports N` over the live hosts |
+| 5 | **Loot**: a human report + raw nmap artifacts | written to `/root/loot/recon/<run>/` |
+
+## Output (loot)
+
+Everything lands under `/root/loot/recon/<UTC-timestamp>_<pid>/`:
+
+```
+summary.txt                  <- the human-readable deliverable (read this first)
+router.{nmap,gnmap,xml}      <- gateway scan + OS detection
+discovery.{nmap,gnmap,xml}   <- host discovery sweep
+services.{nmap,gnmap,xml}    <- service/version scan (XML imports into other tools)
+vlans.txt                    <- VLAN / subnet findings
+```
+
+`summary.txt` is sectioned: run header, **ROUTER/GATEWAY**, **VLANs/SUBNETS**, a
+**HOSTS** table (IP / hostname / MAC / vendor / VLAN), and **PER-HOST OPEN
+PORTS**. The `.xml` files are kept so you can import a run into a notebook or
+another tool back at the desk.
+
+Nothing leaves the device. There is no callback or exfil: you retrieve loot
+yourself over SSH/SharkLink.
+
+## Tuning (top of [`payload.txt`](payload.txt))
+
+| Knob | Default | Notes |
+|------|---------|-------|
+| `NET_MODE` | `DHCP_CLIENT` | `STATIC` for static datacenter drops (fill `STATIC_*`), or `AUTO` |
+| `DHCP_WAIT_SECS` | `30` | how long to wait for an address before failing out |
+| `TOP_PORTS` | `200` | top-N TCP ports per host; raise to `1000` for depth, lower for speed |
+| `NMAP_TIMING` | `-T4` | `-T3` quieter, `-T5` aggressive |
+| `HOST_TIMEOUT` | `90s` | per-host budget so one slow host cannot stall the run |
+| `ROUTER_OS_DETECT` | `1` | run `nmap -O` on the gateway (slower, but that is requirement 1) |
+| `EXTRA_NMAP` | `""` | e.g. `--script nbstat` to add NetBIOS names |
+| `RANDOMIZE_MAC_ADDR` | `0` | leave `0` for consulting work: NAC/inventory often key on MAC |
+| `PASSIVE_VLAN_SECS` | `15` | passive 802.1Q listen window (needs `tcpdump`) |
+| `SCAN_TAGGED_VLANS` | `0` | discover + scan hosts on tagged VLANs (auto-uses the sniffed tag IDs); see the VLAN note. **Off by default** |
+
+## On VLAN discovery (read this)
+
+A single access port only ever shows you **one** VLAN: the untagged access VLAN
+the switch put that port on. The switch strips 802.1Q tags before the frame
+reaches us, so a VLAN *ID* is simply not observable from an access port. The
+payload is honest about that:
+
+- **Always**: it records the access subnet **CIDR** from our own DHCP lease.
+  That is the one VLAN you are actually on.
+- **Passive (default, needs `tcpdump`)**: if the drop is a **trunk**, tagged
+  frames carry their VLAN IDs in the clear. The payload listens briefly and
+  records every tag ID it sees. On a normal access port this correctly reports
+  "none (looks like an access port)".
+- **Active (`SCAN_TAGGED_VLANS=1`, opt-in)**: for each tagged VLAN it found
+  passively, it brings up an `eth0.<vid>` sub-interface, pulls a DHCP lease to
+  recover that VLAN's **CIDR**, then **discovers and port-scans that subnet** and
+  folds those hosts into the report labeled `vlan<vid>`. This is what surfaces
+  devices living on other VLANs of a trunk (e.g. a Wi-Fi client VLAN). If no tags
+  were seen, it falls back to `VLAN_PROBE_IDS`. This is VLAN-hopping: intrusive,
+  noisy, slower (one scan pass per VLAN), and only appropriate on an engagement
+  that explicitly authorizes it. Defaults **off**.
+
+So: CIDR you always get; VLAN IDs you get on a trunk (passive); and with the
+opt-in active scan you also get the **hosts and ports on each tagged VLAN**. The
+report labels every host with the subnet/VLAN it belongs to.
+
+## Limitations / gotchas
+
+- **802.1X / NAC**: a port enforcing 802.1X will not hand you a lease. The
+  payload fails cleanly (red LED, on-screen note, a `summary.txt` explaining
+  why) rather than hanging.
+- **Battery**: on-battery runtime is ~25-35 min. Defaults aim to finish a busy
+  /24 inside that. For a big subnet or `TOP_PORTS=1000`, run on USB-C power.
+- **Scope is L2-local**: it maps the segment the port lands on. Other subnets
+  are only reached via the opt-in VLAN probe.
+- **Requires `nmap`** (ships on the Shark Jack). `tcpdump` is optional and only
+  used for passive tag sniffing (`opkg update && opkg install tcpdump`).
+
+## LED / screen cues
+
+`SETUP` (init) -> `SPECIAL` (waiting for a lease) -> `STAGE1` router -> `STAGE2`
+discovery -> `STAGE3` port/service scan -> `STAGE4` VLANs -> `CLEANUP` writing
+loot -> `FINISH`. Red `FAIL` means no usable network on `eth0`. The display
+mirrors each phase via `SCREEN_WRITE`, shows a spinner during scans and a
+progress bar while the report is assembled, and ends on an `ALERT` with the host
+and open-port counts.
+
+## Setup
+
+Flash -> import the payload -> set it to autorun (or browse-and-run) -> deploy ->
+retrieve loot.

--- a/payloads/library/recon/full_recon/payload.txt
+++ b/payloads/library/recon/full_recon/payload.txt
@@ -1,0 +1,446 @@
+#!/bin/bash
+# ============================================================================
+#  Title:       Wired Network Recon + Loot (Shark Jack Display)
+#  Author:      Brent Mills
+#  Target:      An authorized wired LAN reached via the RJ45 access port.
+#  Category:    recon
+#  Version:     1.0
+#  Firmware:    Shark Jack Display 1.0.1
+# ----------------------------------------------------------------------------
+#  WHAT IT DOES
+#    Plug into a wired drop, walk away, come back to a tidy loot report. In one
+#    autorun pass it maps the segment it landed on:
+#      1. Router / gateway .. hostname, IP, MAC, vendor (OUI), OS + version.
+#      2. VLANs / subnets ... access subnet CIDR (always); 802.1Q tag IDs seen
+#                             passively on a trunk; optional active scan of each
+#                             tagged VLAN (DHCP + host scan), Off by default.
+#      3. Hosts ............. hostname, IP, MAC, vendor, which subnet/VLAN.
+#      4. Open ports ........ per host: port/proto + service/version.
+#      5. Loot .............. a human report plus raw nmap artifacts for later
+#                             analysis, under /root/loot/full_recon/<run>/.
+#
+#  AUTHORIZATION
+#    This payload is ACTIVE: it pulls a DHCP lease and runs nmap against the
+#    LAN. Run it ONLY on networks you own or are contracted to assess, and only
+#    within the agreed scope/time window. Active port scanning of third-party
+#    networks can violate computer-misuse law regardless of intent. It does NOT
+#    exfiltrate: all output stays on-device in /root/loot until you pull it.
+#
+#  RUNTIME / BATTERY
+#    On-battery runtime is short (~25-35 min). Defaults are tuned to finish a
+#    busy /24 inside that window. Turn knobs in CONFIG for depth vs speed.
+# ============================================================================
+
+# ------------------------------- CONFIG -------------------------------------
+# Network bring-up. DHCP_CLIENT is right for a normal access port. For a static
+# drop (some datacenter ports), fill STATIC_* and set NET_MODE="STATIC".
+NET_MODE="DHCP_CLIENT"          # DHCP_CLIENT | AUTO | STATIC
+STATIC_IP="192.168.1.250"       # used only when NET_MODE=STATIC
+STATIC_SUBNET="255.255.255.0"   # used only when NET_MODE=STATIC
+STATIC_GATEWAY="192.168.1.1"    # used only when NET_MODE=STATIC
+DHCP_WAIT_SECS=30               # how long to wait for an address before failing
+
+# Scan depth (per host). Lower = faster, less battery. Service/version scan.
+NMAP_TIMING="-T4"               # -T3 quieter, -T4 brisk, -T5 aggressive
+TOP_PORTS=200                   # top N TCP ports per host (e.g. 100/200/1000)
+HOST_TIMEOUT="90s"              # give up on a single host after this
+ROUTER_OS_DETECT=1              # 1 = run nmap -O on the gateway (slower, worth it)
+EXTRA_NMAP=""                   # e.g. "--script nbstat" to add NetBIOS names
+
+# Identity. Leave MAC alone for consulting work (NAC/inventory often key on it).
+RANDOMIZE_MAC_ADDR=0            # 1 = randomize eth0 MAC before scanning
+
+# VLAN discovery.
+PASSIVE_VLAN_SECS=15            # passively listen this long for 802.1Q tags
+SCAN_TAGGED_VLANS=0             # 1 = also DISCOVER + SCAN hosts on tagged VLANs
+                                #     seen on a trunk: bring up eth0.<vid>, pull
+                                #     DHCP, scan that subnet, and fold its hosts
+                                #     into the report labeled by VLAN. This is
+                                #     active VLAN-hopping: authorized engagements
+                                #     only. Off by default on purpose. (On a plain
+                                #     access port there are no tags, so it no-ops.)
+VLAN_PROBE_IDS=""              # fallback VIDs to try when NO tags are seen
+                                #     passively, e.g. "10 20 30". Empty = scan
+                                #     only the VLANs actually observed on the wire.
+
+# Where loot lands.
+LOOT_BASE="/root/loot/full_recon"
+# ----------------------------------------------------------------------------
+
+
+# ============================ helpers =======================================
+# Small IPv4 math so we can print real network CIDRs and bucket hosts by subnet.
+ip_to_int() { local IFS=.; set -- $1; echo $(( ($1<<24) | ($2<<16) | ($3<<8) | $4 )); }
+int_to_ip() { local i=$1; echo "$(( (i>>24)&255 )).$(( (i>>16)&255 )).$(( (i>>8)&255 )).$(( i&255 ))"; }
+mask_for()  { local p=$1; echo $(( (0xFFFFFFFF << (32-p)) & 0xFFFFFFFF )); }
+network_cidr() {            # network_cidr <ip> <prefix> -> "net/prefix"
+  local ip=$1 p=$2 m; m=$(mask_for "$p")
+  echo "$(int_to_ip $(( $(ip_to_int "$ip") & m )))/$p"
+}
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Quiet wrappers so a missing display/LED binary never aborts the scan.
+say()  { SCREEN_WRITE "$*" 2>/dev/null; }      # one line to the screen
+glow() { LED "$@" 2>/dev/null; }               # LED state/colour
+spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
+spin_down() { STOP_SPINNER 2>/dev/null; }
+
+# Randomize eth0's MAC in raw shell (no DuckyScript command exists for this).
+# Prefer macchanger; otherwise build a random locally-administered unicast MAC.
+randomize_mac() {
+  if have macchanger; then
+    ip link set eth0 down 2>/dev/null
+    macchanger -r eth0 >/dev/null 2>&1
+    ip link set eth0 up 2>/dev/null
+    return
+  fi
+  local bytes b1 mac
+  bytes=$(od -An -N6 -tu1 /dev/urandom 2>/dev/null)            # 6 random bytes -> decimals
+  set -- $bytes
+  [ $# -eq 6 ] || return                                       # no /dev/urandom: skip quietly
+  b1=$(( ($1 & 0xFC) | 0x02 ))                                 # locally-administered + unicast
+  mac=$(printf '%02x:%02x:%02x:%02x:%02x:%02x' "$b1" "$2" "$3" "$4" "$5" "$6")
+  ip link set eth0 down 2>/dev/null
+  ip link set eth0 address "$mac" 2>/dev/null
+  ip link set eth0 up 2>/dev/null
+}
+
+# Which known subnet/VLAN contains an IP (probed VLANs win, else "access").
+VLAN_SUBNETS=""                                # "vid:net/prefix vid:net/prefix"
+vlan_for_ip() {
+  local ip=$1 ipi entry vid cidr net p m
+  ipi=$(ip_to_int "$ip")
+  for entry in $VLAN_SUBNETS; do
+    vid=${entry%%:*}; cidr=${entry#*:}; net=${cidr%/*}; p=${cidr#*/}
+    m=$(mask_for "$p")
+    if [ $(( ipi & m )) -eq $(( $(ip_to_int "$net") & m )) ]; then
+      echo "vlan$vid"; return
+    fi
+  done
+  echo "access"
+}
+
+# Parse one nmap -sV normal-output file and APPEND rows to the running tables:
+#   HOSTSF: IP \t HOST \t MAC \t VENDOR     PORTSF: "### ip host" + open-port lines
+# Append mode (>>) so the native VLAN and every tagged VLAN accumulate together.
+parse_services() {                              # parse_services <services.nmap>
+  awk -v HOSTSF="$HOSTSF" -v PORTSF="$PORTSF" '
+    function flush(   k) {
+      if (ip=="") return
+      printf "%s\t%s\t%s\t%s\n", ip, host, mac, vendor >> HOSTSF
+      printf "### %s  %s\n", ip, host >> PORTSF
+      if (np==0) print "    (no open ports in scanned range)" >> PORTSF
+      for (k=1;k<=np;k++) print "    " ports[k] >> PORTSF
+    }
+    /^Nmap scan report for / {
+      flush()
+      line=$0; sub(/^Nmap scan report for /,"",line)
+      if (line ~ /\(.*\)/) { host=line; sub(/ \(.*/,"",host); ip=line; sub(/.*\(/,"",ip); sub(/\)/,"",ip) }
+      else { host="-"; ip=line }
+      mac="-"; vendor="-"; np=0; delete ports
+    }
+    /^[0-9]+\/(tcp|udp)[ \t]+open/ {
+      pp=$1; svc=$3; ver=""
+      for (i=4;i<=NF;i++) ver=ver (i>4?" ":"") $i
+      if (ver=="") ver="-"
+      ports[++np]=pp "  " svc "  " ver
+    }
+    /^MAC Address: / {
+      mac=$3; vendor=$0
+      sub(/^MAC Address: [^ ]+ ?/,"",vendor); gsub(/^\(|\)$/,"",vendor)
+      if (vendor=="") vendor="-"
+    }
+    END { flush() }
+  ' "$1" 2>/dev/null
+}
+
+# Discover + service-scan a subnet through a given interface, appending results.
+# Echoes the live-host count. Used for the native VLAN and each tagged VLAN.
+scan_subnet() {                                 # scan_subnet <iface> <cidr> <basename>
+  local iface=$1 cidr=$2 base=$3 n=0
+  nmap -sn $NMAP_TIMING -e "$iface" -oA "${base}_discovery" "$cidr" >/dev/null 2>&1
+  awk '/Status: Up/{print $2}' "${base}_discovery.gnmap" 2>/dev/null | sort -u > "${base}_up.txt"
+  n=$(wc -l < "${base}_up.txt" 2>/dev/null | tr -d ' '); [ -z "$n" ] && n=0
+  if [ "$n" -gt 0 ]; then
+    nmap -sV $NMAP_TIMING --top-ports "$TOP_PORTS" --host-timeout "$HOST_TIMEOUT" \
+         $EXTRA_NMAP -e "$iface" -iL "${base}_up.txt" -oA "${base}_services" >/dev/null 2>&1
+    parse_services "${base}_services.nmap"
+  fi
+  echo "$n"
+}
+# ============================================================================
+
+
+# ------------------------------ PHASE: SETUP --------------------------------
+glow SETUP
+CLEAR_SCREEN 2>/dev/null
+say "Wired recon starting"
+
+if ! have nmap; then
+  glow FAIL
+  say "nmap missing - abort"
+  ALERT "nmap not installed on this device" 8 2>/dev/null
+  exit 1
+fi
+
+RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
+mkdir -p "$RUN"
+REPORT="$RUN/summary.txt"
+HOSTSF="$RUN/_hosts.tsv"        # IP \t HOST \t MAC \t VENDOR  (parser output)
+PORTSF="$RUN/_ports.txt"        # per-host open-port blocks (parser output)
+VLANF="$RUN/vlans.txt"
+: > "$VLANF"; : > "$HOSTSF"; : > "$PORTSF"   # accumulators (native + tagged VLANs)
+
+# Optional: identity + clock hygiene before we touch the wire.
+[ "$RANDOMIZE_MAC_ADDR" = "1" ] && { say "Randomizing MAC"; randomize_mac; }
+
+
+# --------------------------- PHASE: NETWORK UP ------------------------------
+glow SPECIAL
+say "Bringing up eth0 ($NET_MODE)"
+case "$NET_MODE" in
+  STATIC) NETMODE STATIC IP_${STATIC_IP} SUBNET_${STATIC_SUBNET} GATEWAY_${STATIC_GATEWAY} 2>/dev/null ;;
+  AUTO)   NETMODE AUTO 2>/dev/null ;;
+  *)      NETMODE DHCP_CLIENT 2>/dev/null ;;
+esac
+
+# Block until carrier is up before waiting on a lease (framework helper; the race fix).
+WAIT_FOR_LINK 2>/dev/null
+
+# Wait for an IPv4 address on eth0. WAIT_FOR_IP would block forever, so keep a
+# bounded loop to fail cleanly on a NAC'd / no-DHCP / dead drop.
+IP=""; PREFIX=""
+for i in $(seq 1 "$DHCP_WAIT_SECS"); do
+  line=$(ip -o -4 addr show eth0 2>/dev/null | awk '{print $4}')
+  if [ -n "$line" ]; then IP=${line%/*}; PREFIX=${line#*/}; break; fi
+  sleep 1
+done
+
+if [ -z "$IP" ]; then
+  glow FAIL
+  say "No lease on eth0"
+  say "NAC / 802.1X? dead port?"
+  { echo "FAILED: no IPv4 on eth0 after ${DHCP_WAIT_SECS}s (NET_MODE=$NET_MODE)."
+    echo "Likely 802.1X/NAC, no DHCP, or a dead drop."; } > "$REPORT"
+  ALERT "No network on eth0 - see loot" 8 2>/dev/null
+  exit 1
+fi
+
+GATEWAY=$(ip route 2>/dev/null | awk '/default/{print $3; exit}')
+ACCESS_CIDR=$(network_cidr "$IP" "$PREFIX")
+say "IP $IP/$PREFIX"
+say "GW $GATEWAY"
+
+# Best-effort clock sync so the loot timestamp is real (non-fatal if offline).
+ENABLE_NTP 2>/dev/null
+
+
+# --------------------------- PHASE: ROUTER ----------------------------------
+glow STAGE1
+say "Profiling gateway"
+ROUTER_OS="-"
+if [ -n "$GATEWAY" ]; then
+  spin_up "Scanning router $GATEWAY"
+  if [ "$ROUTER_OS_DETECT" = "1" ]; then
+    nmap -O $NMAP_TIMING --host-timeout 120s -oA "$RUN/router" "$GATEWAY" >/dev/null 2>&1
+  else
+    nmap -sV $NMAP_TIMING --host-timeout "$HOST_TIMEOUT" -oA "$RUN/router" "$GATEWAY" >/dev/null 2>&1
+  fi
+  spin_down
+  # Pull a single best OS string out of the router scan.
+  ROUTER_OS=$(grep -m1 -E '^OS details:'            "$RUN/router.nmap" 2>/dev/null | sed 's/^OS details: //')
+  [ -z "$ROUTER_OS" ] && ROUTER_OS=$(grep -m1 -E '^Running:'           "$RUN/router.nmap" 2>/dev/null | sed 's/^Running: //')
+  [ -z "$ROUTER_OS" ] && ROUTER_OS=$(grep -m1 -E '^Aggressive OS guess' "$RUN/router.nmap" 2>/dev/null | sed 's/^Aggressive OS guesses: //')
+  [ -z "$ROUTER_OS" ] && ROUTER_OS="-"
+fi
+
+
+# ----------------------- PHASE: HOST DISCOVERY ------------------------------
+glow STAGE2
+say "Discovering hosts"
+spin_up "ARP/ping sweep $ACCESS_CIDR"
+# On a local segment, nmap uses ARP for discovery: reliable even when ICMP is
+# filtered. We scan the whole access subnet derived from our own lease.
+nmap -sn $NMAP_TIMING -oA "$RUN/discovery" "$IP/$PREFIX" >/dev/null 2>&1
+spin_down
+awk '/Status: Up/{print $2}' "$RUN/discovery.gnmap" 2>/dev/null | sort -u > "$RUN/up_hosts.txt"
+UPCOUNT=$(wc -l < "$RUN/up_hosts.txt" 2>/dev/null | tr -d ' ')
+[ -z "$UPCOUNT" ] && UPCOUNT=0
+say "$UPCOUNT hosts up"
+
+
+# --------------------- PHASE: SERVICE / PORT SCAN ---------------------------
+glow STAGE3
+if [ "$UPCOUNT" -gt 0 ]; then
+  spin_up "Port/service scan x$UPCOUNT"
+  nmap -sV $NMAP_TIMING --top-ports "$TOP_PORTS" --host-timeout "$HOST_TIMEOUT" \
+       $EXTRA_NMAP -iL "$RUN/up_hosts.txt" -oA "$RUN/services" >/dev/null 2>&1
+  spin_down
+else
+  : > "$RUN/services.nmap"
+fi
+
+# Parse the native-VLAN service scan into the running hosts + ports tables.
+parse_services "$RUN/services.nmap"
+
+
+# --------------------------- PHASE: VLANs -----------------------------------
+glow STAGE4
+say "Mapping VLANs"
+{
+  echo "Access subnet (untagged): $ACCESS_CIDR   [our lease: $IP/$PREFIX]"
+} >> "$VLANF"
+
+# Passive: watch for 802.1Q tags. Yields nothing on an access port (expected),
+# and the tagged VID list on a trunk. Needs tcpdump.
+PASSIVE_TAGS=""
+if have tcpdump; then
+  spin_up "Listening ${PASSIVE_VLAN_SECS}s for 802.1Q"
+  timeout "${PASSIVE_VLAN_SECS}s" tcpdump -e -nn -i eth0 -c 300 vlan 2>/dev/null \
+    | grep -oE 'vlan [0-9]+' | awk '{print $2}' | sort -un > "$RUN/_tags.txt"
+  spin_down
+  PASSIVE_TAGS=$(tr '\n' ' ' < "$RUN/_tags.txt" 2>/dev/null)
+  if [ -n "$PASSIVE_TAGS" ]; then
+    echo "Tagged VLAN IDs seen passively (trunk port): $PASSIVE_TAGS" >> "$VLANF"
+  else
+    echo "Tagged VLAN IDs seen passively: none (looks like an access port)" >> "$VLANF"
+  fi
+else
+  echo "Tagged VLAN IDs: tcpdump not installed - passive tag sniff skipped." >> "$VLANF"
+fi
+
+# Active (opt-in): for each tagged VLAN, bring up eth0.<vid>, pull DHCP, then
+# DISCOVER + SCAN that subnet and fold its hosts into the report (labeled vlanN).
+# Candidates come from the passive sniff; VLAN_PROBE_IDS is a fallback if none.
+if [ "$SCAN_TAGGED_VLANS" = "1" ]; then
+  CANDIDATES="$PASSIVE_TAGS"
+  [ -z "$CANDIDATES" ] && CANDIDATES="$VLAN_PROBE_IDS"
+  if [ -z "$CANDIDATES" ]; then
+    echo "Tagged-VLAN scan on, but no VIDs to try (none seen, none in VLAN_PROBE_IDS)." >> "$VLANF"
+  elif have ip && have udhcpc; then
+    lsmod 2>/dev/null | grep -q 8021q || modprobe 8021q 2>/dev/null   # ensure 802.1Q support
+    echo "Tagged-VLAN scan (VIDs: $CANDIDATES):" >> "$VLANF"
+    for vid in $CANDIDATES; do
+      glow STAGE5
+      spin_up "VLAN $vid: lease + scan"
+      ip link add link eth0 name "eth0.$vid" type vlan id "$vid" 2>/dev/null
+      if ! ip link show "eth0.$vid" >/dev/null 2>&1; then
+        # Interface never came into being: the 802.1Q kernel module is missing.
+        echo "  VLAN $vid -> could NOT create tagged interface - install 802.1Q: opkg install kmod-8021q" >> "$VLANF"
+      else
+        ip link set "eth0.$vid" up 2>/dev/null
+        udhcpc -i "eth0.$vid" -n -q -t 4 -T 3 >/dev/null 2>&1
+        vline=$(ip addr show "eth0.$vid" 2>/dev/null | grep -oE 'inet [0-9.]+/[0-9]+' | head -1 | awk '{print $2}')
+        if [ -z "$vline" ]; then
+          # Tagging works, but nothing answered: this port likely does not trunk this VID.
+          echo "  VLAN $vid -> interface up but NO DHCP lease (port may not trunk VLAN $vid, or no DHCP server there)" >> "$VLANF"
+        else
+          vcidr=$(network_cidr "${vline%/*}" "${vline#*/}")
+          if [ "$vcidr" = "$ACCESS_CIDR" ]; then
+            echo "  VLAN $vid -> $vcidr (same as access subnet, skipped)" >> "$VLANF"
+          else
+            VLAN_SUBNETS="$VLAN_SUBNETS ${vid}:${vcidr}"        # so hosts get labeled vlan$vid
+            vn=$(scan_subnet "eth0.$vid" "$vcidr" "$RUN/vlan$vid")
+            echo "  VLAN $vid -> $vcidr   [$vn hosts, lease ${vline}]" >> "$VLANF"
+          fi
+        fi
+        ip link set "eth0.$vid" down 2>/dev/null
+        ip link del "eth0.$vid" 2>/dev/null
+      fi
+      spin_down
+    done
+  else
+    echo "Tagged-VLAN scan requested but 'ip'/'udhcpc' unavailable - skipped." >> "$VLANF"
+  fi
+fi
+
+
+# --------------------------- PHASE: WRITE LOOT ------------------------------
+glow CLEANUP
+say "Writing loot"
+# Total live hosts across the native VLAN + any scanned tagged VLANs.
+UPCOUNT=$(wc -l < "$HOSTSF" 2>/dev/null | tr -d ' '); [ -z "$UPCOUNT" ] && UPCOUNT=0
+CREATE_PROGRESS_BAR "Building report" 2>/dev/null
+
+# Router line lookup from the parsed hosts table (the gateway is one host row).
+RHOST="-"; RMAC="-"; RVEND="-"
+if [ -n "$GATEWAY" ]; then
+  rrow=$(awk -F'\t' -v g="$GATEWAY" '$1==g{print; exit}' "$HOSTSF" 2>/dev/null)
+  if [ -n "$rrow" ]; then
+    RHOST=$(echo "$rrow" | cut -f2); RMAC=$(echo "$rrow" | cut -f3); RVEND=$(echo "$rrow" | cut -f4)
+  fi
+fi
+RPORTS=$(awk -v g="$GATEWAY" '
+  $0=="### "g"  -" || index($0,"### "g"  ")==1 {grab=1; next}
+  /^### /{grab=0}
+  grab && /^    [0-9]/{gsub(/^ +/,""); printf "%s; ", $0}
+' "$PORTSF" 2>/dev/null)
+[ -z "$RPORTS" ] && RPORTS="(see services.nmap)"
+
+{
+  echo "=========================================================="
+  echo " SHARK JACK DISPLAY - WIRED RECON REPORT"
+  echo "=========================================================="
+  echo " Run time : $(date -u '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null)"
+  echo " Our lease: $IP/$PREFIX   ($NET_MODE)"
+  echo " Gateway  : ${GATEWAY:-unknown}"
+  echo " Subnet   : $ACCESS_CIDR"
+  echo " Hosts up : $UPCOUNT"
+  echo ""
+  echo "---- ROUTER / GATEWAY ------------------------------------"
+  echo " IP        : ${GATEWAY:-unknown}"
+  echo " Hostname  : $RHOST"
+  echo " MAC       : $RMAC"
+  echo " Vendor    : $RVEND"
+  echo " OS        : $ROUTER_OS"
+  echo " Open ports: $RPORTS"
+  echo ""
+  echo "---- VLANs / SUBNETS -------------------------------------"
+  cat "$VLANF"
+  echo ""
+  echo "---- HOSTS ($UPCOUNT up) ---------------------------------"
+  printf " %-15s %-26s %-18s %-22s %s\n" "IP" "HOSTNAME" "MAC" "VENDOR" "VLAN"
+  printf " %-15s %-26s %-18s %-22s %s\n" "---------------" "--------------------------" "------------------" "----------------------" "-----"
+} > "$REPORT"
+
+# Hosts table, with a live progress bar as we walk each row.
+idx=0
+while IFS=$'\t' read -r hip hhost hmac hvend; do
+  [ -z "$hip" ] && continue
+  idx=$((idx+1))
+  printf " %-15s %-26s %-18s %-22s %s\n" \
+    "$hip" "${hhost:--}" "${hmac:--}" "${hvend:--}" "$(vlan_for_ip "$hip")" >> "$REPORT"
+  if [ "$UPCOUNT" -gt 0 ]; then SET_PROGRESS $(( idx * 100 / UPCOUNT )) 2>/dev/null; fi
+done < "$HOSTSF"
+
+{
+  echo ""
+  echo "---- PER-HOST OPEN PORTS ---------------------------------"
+  echo " (port/proto  service  version)"
+  echo ""
+  cat "$PORTSF"
+  echo ""
+  echo "---- RAW ARTIFACTS ---------------------------------------"
+  echo " router.{nmap,gnmap,xml}    - gateway scan + OS detection"
+  echo " discovery.{nmap,gnmap,xml} - host discovery sweep"
+  echo " services.{nmap,gnmap,xml}  - service/version scan (import-ready XML)"
+  echo " vlanNN_*.{nmap,gnmap,xml}  - per tagged-VLAN scans (when SCAN_TAGGED_VLANS=1)"
+  echo " vlans.txt                  - VLAN/subnet findings"
+  echo "=========================================================="
+} >> "$REPORT"
+
+SET_PROGRESS 100 2>/dev/null
+# Tidy internal parser scratch (keep the report + raw nmap artifacts).
+rm -f "$HOSTSF" "$PORTSF" "$RUN/_tags.txt" "$RUN"/vlan*_up.txt 2>/dev/null
+
+
+# ------------------------------ PHASE: DONE ---------------------------------
+glow FINISH
+PORTLINES=$(grep -cE '^    [0-9]+/(tcp|udp)' "$REPORT" 2>/dev/null)
+[ -z "$PORTLINES" ] && PORTLINES=0
+CLEAR_SCREEN 2>/dev/null
+say "Recon complete"
+say "Hosts: $UPCOUNT  Ports: $PORTLINES"
+say "Loot: ${RUN#/root/}"
+ALERT "Recon done: $UPCOUNT hosts, $PORTLINES open ports. Loot saved." 12 2>/dev/null
+exit 0

--- a/payloads/library/recon/full_recon/payload.txt
+++ b/payloads/library/recon/full_recon/payload.txt
@@ -5,7 +5,7 @@
 #  Target:      An authorized wired LAN reached via the RJ45 access port.
 #  Category:    recon
 #  Version:     1.0
-#  Firmware:    Shark Jack Display 1.0.1
+#  Firmware:    Tested on Shark Jack Display 1.0.1
 # ----------------------------------------------------------------------------
 #  WHAT IT DOES
 #    Plug into a wired drop, walk away, come back to a tidy loot report. In one

--- a/payloads/library/recon/full_recon/payload.txt
+++ b/payloads/library/recon/full_recon/payload.txt
@@ -79,9 +79,8 @@ network_cidr() {            # network_cidr <ip> <prefix> -> "net/prefix"
 }
 have() { command -v "$1" >/dev/null 2>&1; }
 
-# Quiet wrappers so a missing display/LED binary never aborts the scan.
+# Quiet wrappers so a missing display binary never aborts the scan.
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }      # one line to the screen
-glow() { LED "$@" 2>/dev/null; }               # LED state/colour
 spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 
@@ -172,12 +171,12 @@ scan_subnet() {                                 # scan_subnet <iface> <cidr> <ba
 
 
 # ------------------------------ PHASE: SETUP --------------------------------
-glow SETUP
+LED SETUP
 CLEAR_SCREEN 2>/dev/null
 say "Wired recon starting"
 
 if ! have nmap; then
-  glow FAIL
+  LED FAIL
   say "nmap missing - abort"
   ALERT "nmap not installed on this device" 8 2>/dev/null
   exit 1
@@ -196,7 +195,7 @@ VLANF="$RUN/vlans.txt"
 
 
 # --------------------------- PHASE: NETWORK UP ------------------------------
-glow SPECIAL
+LED SPECIAL
 say "Bringing up eth0 ($NET_MODE)"
 case "$NET_MODE" in
   STATIC) NETMODE STATIC IP_${STATIC_IP} SUBNET_${STATIC_SUBNET} GATEWAY_${STATIC_GATEWAY} 2>/dev/null ;;
@@ -217,7 +216,7 @@ for i in $(seq 1 "$DHCP_WAIT_SECS"); do
 done
 
 if [ -z "$IP" ]; then
-  glow FAIL
+  LED FAIL
   say "No lease on eth0"
   say "NAC / 802.1X? dead port?"
   { echo "FAILED: no IPv4 on eth0 after ${DHCP_WAIT_SECS}s (NET_MODE=$NET_MODE)."
@@ -236,7 +235,7 @@ ENABLE_NTP 2>/dev/null
 
 
 # --------------------------- PHASE: ROUTER ----------------------------------
-glow STAGE1
+LED STAGE1
 say "Profiling gateway"
 ROUTER_OS="-"
 if [ -n "$GATEWAY" ]; then
@@ -256,7 +255,7 @@ fi
 
 
 # ----------------------- PHASE: HOST DISCOVERY ------------------------------
-glow STAGE2
+LED STAGE2
 say "Discovering hosts"
 spin_up "ARP/ping sweep $ACCESS_CIDR"
 # On a local segment, nmap uses ARP for discovery: reliable even when ICMP is
@@ -270,7 +269,7 @@ say "$UPCOUNT hosts up"
 
 
 # --------------------- PHASE: SERVICE / PORT SCAN ---------------------------
-glow STAGE3
+LED STAGE3
 if [ "$UPCOUNT" -gt 0 ]; then
   spin_up "Port/service scan x$UPCOUNT"
   nmap -sV $NMAP_TIMING --top-ports "$TOP_PORTS" --host-timeout "$HOST_TIMEOUT" \
@@ -285,7 +284,7 @@ parse_services "$RUN/services.nmap"
 
 
 # --------------------------- PHASE: VLANs -----------------------------------
-glow STAGE4
+LED STAGE4
 say "Mapping VLANs"
 {
   echo "Access subnet (untagged): $ACCESS_CIDR   [our lease: $IP/$PREFIX]"
@@ -321,7 +320,7 @@ if [ "$SCAN_TAGGED_VLANS" = "1" ]; then
     lsmod 2>/dev/null | grep -q 8021q || modprobe 8021q 2>/dev/null   # ensure 802.1Q support
     echo "Tagged-VLAN scan (VIDs: $CANDIDATES):" >> "$VLANF"
     for vid in $CANDIDATES; do
-      glow STAGE5
+      LED STAGE5
       spin_up "VLAN $vid: lease + scan"
       ip link add link eth0 name "eth0.$vid" type vlan id "$vid" 2>/dev/null
       if ! ip link show "eth0.$vid" >/dev/null 2>&1; then
@@ -356,7 +355,7 @@ fi
 
 
 # --------------------------- PHASE: WRITE LOOT ------------------------------
-glow CLEANUP
+LED CLEANUP
 say "Writing loot"
 # Total live hosts across the native VLAN + any scanned tagged VLANs.
 UPCOUNT=$(wc -l < "$HOSTSF" 2>/dev/null | tr -d ' '); [ -z "$UPCOUNT" ] && UPCOUNT=0
@@ -435,7 +434,7 @@ rm -f "$HOSTSF" "$PORTSF" "$RUN/_tags.txt" "$RUN"/vlan*_up.txt 2>/dev/null
 
 
 # ------------------------------ PHASE: DONE ---------------------------------
-glow FINISH
+LED FINISH
 PORTLINES=$(grep -cE '^    [0-9]+/(tcp|udp)' "$REPORT" 2>/dev/null)
 [ -z "$PORTLINES" ] && PORTLINES=0
 CLEAR_SCREEN 2>/dev/null

--- a/payloads/library/recon/full_recon/payload.txt
+++ b/payloads/library/recon/full_recon/payload.txt
@@ -79,9 +79,6 @@ network_cidr() {            # network_cidr <ip> <prefix> -> "net/prefix"
 }
 have() { command -v "$1" >/dev/null 2>&1; }
 
-# Quiet wrappers so a missing display binary never aborts the scan.
-say()  { SCREEN_WRITE "$*" 2>/dev/null; }      # one line to the screen
-
 # Randomize eth0's MAC in raw shell (no DuckyScript command exists for this).
 # Prefer macchanger; otherwise build a random locally-administered unicast MAC.
 randomize_mac() {
@@ -171,11 +168,11 @@ scan_subnet() {                                 # scan_subnet <iface> <cidr> <ba
 # ------------------------------ PHASE: SETUP --------------------------------
 LED SETUP
 CLEAR_SCREEN 2>/dev/null
-say "Wired recon starting"
+SCREEN_WRITE "Wired recon starting"
 
 if ! have nmap; then
   LED FAIL
-  say "nmap missing - abort"
+  SCREEN_WRITE "nmap missing - abort"
   ALERT "nmap not installed on this device" 8 2>/dev/null
   exit 1
 fi
@@ -189,12 +186,12 @@ VLANF="$RUN/vlans.txt"
 : > "$VLANF"; : > "$HOSTSF"; : > "$PORTSF"   # accumulators (native + tagged VLANs)
 
 # Optional: identity + clock hygiene before we touch the wire.
-[ "$RANDOMIZE_MAC_ADDR" = "1" ] && { say "Randomizing MAC"; randomize_mac; }
+[ "$RANDOMIZE_MAC_ADDR" = "1" ] && { SCREEN_WRITE "Randomizing MAC"; randomize_mac; }
 
 
 # --------------------------- PHASE: NETWORK UP ------------------------------
 LED SPECIAL
-say "Bringing up eth0 ($NET_MODE)"
+SCREEN_WRITE "Bringing up eth0 ($NET_MODE)"
 case "$NET_MODE" in
   STATIC) NETMODE STATIC IP_${STATIC_IP} SUBNET_${STATIC_SUBNET} GATEWAY_${STATIC_GATEWAY} 2>/dev/null ;;
   AUTO)   NETMODE AUTO 2>/dev/null ;;
@@ -215,8 +212,8 @@ done
 
 if [ -z "$IP" ]; then
   LED FAIL
-  say "No lease on eth0"
-  say "NAC / 802.1X? dead port?"
+  SCREEN_WRITE "No lease on eth0"
+  SCREEN_WRITE "NAC / 802.1X? dead port?"
   { echo "FAILED: no IPv4 on eth0 after ${DHCP_WAIT_SECS}s (NET_MODE=$NET_MODE)."
     echo "Likely 802.1X/NAC, no DHCP, or a dead drop."; } > "$REPORT"
   ALERT "No network on eth0 - see loot" 8 2>/dev/null
@@ -225,8 +222,8 @@ fi
 
 GATEWAY=$(ip route 2>/dev/null | awk '/default/{print $3; exit}')
 ACCESS_CIDR=$(network_cidr "$IP" "$PREFIX")
-say "IP $IP/$PREFIX"
-say "GW $GATEWAY"
+SCREEN_WRITE "IP $IP/$PREFIX"
+SCREEN_WRITE "GW $GATEWAY"
 
 # Best-effort clock sync so the loot timestamp is real (non-fatal if offline).
 ENABLE_NTP 2>/dev/null
@@ -234,7 +231,7 @@ ENABLE_NTP 2>/dev/null
 
 # --------------------------- PHASE: ROUTER ----------------------------------
 LED STAGE1
-say "Profiling gateway"
+SCREEN_WRITE "Profiling gateway"
 ROUTER_OS="-"
 if [ -n "$GATEWAY" ]; then
   CREATE_SPINNER "Scanning router $GATEWAY"
@@ -254,7 +251,7 @@ fi
 
 # ----------------------- PHASE: HOST DISCOVERY ------------------------------
 LED STAGE2
-say "Discovering hosts"
+SCREEN_WRITE "Discovering hosts"
 CREATE_SPINNER "ARP/ping sweep $ACCESS_CIDR"
 # On a local segment, nmap uses ARP for discovery: reliable even when ICMP is
 # filtered. We scan the whole access subnet derived from our own lease.
@@ -263,7 +260,7 @@ STOP_SPINNER
 awk '/Status: Up/{print $2}' "$RUN/discovery.gnmap" 2>/dev/null | sort -u > "$RUN/up_hosts.txt"
 UPCOUNT=$(wc -l < "$RUN/up_hosts.txt" 2>/dev/null | tr -d ' ')
 [ -z "$UPCOUNT" ] && UPCOUNT=0
-say "$UPCOUNT hosts up"
+SCREEN_WRITE "$UPCOUNT hosts up"
 
 
 # --------------------- PHASE: SERVICE / PORT SCAN ---------------------------
@@ -283,7 +280,7 @@ parse_services "$RUN/services.nmap"
 
 # --------------------------- PHASE: VLANs -----------------------------------
 LED STAGE4
-say "Mapping VLANs"
+SCREEN_WRITE "Mapping VLANs"
 {
   echo "Access subnet (untagged): $ACCESS_CIDR   [our lease: $IP/$PREFIX]"
 } >> "$VLANF"
@@ -354,7 +351,7 @@ fi
 
 # --------------------------- PHASE: WRITE LOOT ------------------------------
 LED CLEANUP
-say "Writing loot"
+SCREEN_WRITE "Writing loot"
 # Total live hosts across the native VLAN + any scanned tagged VLANs.
 UPCOUNT=$(wc -l < "$HOSTSF" 2>/dev/null | tr -d ' '); [ -z "$UPCOUNT" ] && UPCOUNT=0
 CREATE_PROGRESS_BAR "Building report" 2>/dev/null
@@ -436,8 +433,8 @@ LED FINISH
 PORTLINES=$(grep -cE '^    [0-9]+/(tcp|udp)' "$REPORT" 2>/dev/null)
 [ -z "$PORTLINES" ] && PORTLINES=0
 CLEAR_SCREEN 2>/dev/null
-say "Recon complete"
-say "Hosts: $UPCOUNT  Ports: $PORTLINES"
-say "Loot: ${RUN#/root/}"
+SCREEN_WRITE "Recon complete"
+SCREEN_WRITE "Hosts: $UPCOUNT  Ports: $PORTLINES"
+SCREEN_WRITE "Loot: ${RUN#/root/}"
 ALERT "Recon done: $UPCOUNT hosts, $PORTLINES open ports. Loot saved." 12 2>/dev/null
 exit 0

--- a/payloads/library/recon/full_recon/payload.txt
+++ b/payloads/library/recon/full_recon/payload.txt
@@ -81,7 +81,6 @@ have() { command -v "$1" >/dev/null 2>&1; }
 
 # Quiet wrappers so a missing display binary never aborts the scan.
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }      # one line to the screen
-spin_down() { STOP_SPINNER 2>/dev/null; }
 
 # Randomize eth0's MAC in raw shell (no DuckyScript command exists for this).
 # Prefer macchanger; otherwise build a random locally-administered unicast MAC.
@@ -244,7 +243,7 @@ if [ -n "$GATEWAY" ]; then
   else
     nmap -sV $NMAP_TIMING --host-timeout "$HOST_TIMEOUT" -oA "$RUN/router" "$GATEWAY" >/dev/null 2>&1
   fi
-  spin_down
+  STOP_SPINNER
   # Pull a single best OS string out of the router scan.
   ROUTER_OS=$(grep -m1 -E '^OS details:'            "$RUN/router.nmap" 2>/dev/null | sed 's/^OS details: //')
   [ -z "$ROUTER_OS" ] && ROUTER_OS=$(grep -m1 -E '^Running:'           "$RUN/router.nmap" 2>/dev/null | sed 's/^Running: //')
@@ -260,7 +259,7 @@ CREATE_SPINNER "ARP/ping sweep $ACCESS_CIDR"
 # On a local segment, nmap uses ARP for discovery: reliable even when ICMP is
 # filtered. We scan the whole access subnet derived from our own lease.
 nmap -sn $NMAP_TIMING -oA "$RUN/discovery" "$IP/$PREFIX" >/dev/null 2>&1
-spin_down
+STOP_SPINNER
 awk '/Status: Up/{print $2}' "$RUN/discovery.gnmap" 2>/dev/null | sort -u > "$RUN/up_hosts.txt"
 UPCOUNT=$(wc -l < "$RUN/up_hosts.txt" 2>/dev/null | tr -d ' ')
 [ -z "$UPCOUNT" ] && UPCOUNT=0
@@ -273,7 +272,7 @@ if [ "$UPCOUNT" -gt 0 ]; then
   CREATE_SPINNER "Port/service scan x$UPCOUNT"
   nmap -sV $NMAP_TIMING --top-ports "$TOP_PORTS" --host-timeout "$HOST_TIMEOUT" \
        $EXTRA_NMAP -iL "$RUN/up_hosts.txt" -oA "$RUN/services" >/dev/null 2>&1
-  spin_down
+  STOP_SPINNER
 else
   : > "$RUN/services.nmap"
 fi
@@ -296,7 +295,7 @@ if have tcpdump; then
   CREATE_SPINNER "Listening ${PASSIVE_VLAN_SECS}s for 802.1Q"
   timeout "${PASSIVE_VLAN_SECS}s" tcpdump -e -nn -i eth0 -c 300 vlan 2>/dev/null \
     | grep -oE 'vlan [0-9]+' | awk '{print $2}' | sort -un > "$RUN/_tags.txt"
-  spin_down
+  STOP_SPINNER
   PASSIVE_TAGS=$(tr '\n' ' ' < "$RUN/_tags.txt" 2>/dev/null)
   if [ -n "$PASSIVE_TAGS" ]; then
     echo "Tagged VLAN IDs seen passively (trunk port): $PASSIVE_TAGS" >> "$VLANF"
@@ -345,7 +344,7 @@ if [ "$SCAN_TAGGED_VLANS" = "1" ]; then
         ip link set "eth0.$vid" down 2>/dev/null
         ip link del "eth0.$vid" 2>/dev/null
       fi
-      spin_down
+      STOP_SPINNER
     done
   else
     echo "Tagged-VLAN scan requested but 'ip'/'udhcpc' unavailable - skipped." >> "$VLANF"

--- a/payloads/library/recon/full_recon/payload.txt
+++ b/payloads/library/recon/full_recon/payload.txt
@@ -59,7 +59,7 @@ SCAN_TAGGED_VLANS=0             # 1 = also DISCOVER + SCAN hosts on tagged VLANs
                                 #     active VLAN-hopping: authorized engagements
                                 #     only. Off by default on purpose. (On a plain
                                 #     access port there are no tags, so it no-ops.)
-VLAN_PROBE_IDS=""              # fallback VIDs to try when NO tags are seen
+VLAN_PROBE_IDS=""               # fallback VIDs to try when NO tags are seen
                                 #     passively, e.g. "10 20 30". Empty = scan
                                 #     only the VLANs actually observed on the wire.
 

--- a/payloads/library/recon/full_recon/payload.txt
+++ b/payloads/library/recon/full_recon/payload.txt
@@ -81,7 +81,6 @@ have() { command -v "$1" >/dev/null 2>&1; }
 
 # Quiet wrappers so a missing display binary never aborts the scan.
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }      # one line to the screen
-spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 
 # Randomize eth0's MAC in raw shell (no DuckyScript command exists for this).
@@ -239,7 +238,7 @@ LED STAGE1
 say "Profiling gateway"
 ROUTER_OS="-"
 if [ -n "$GATEWAY" ]; then
-  spin_up "Scanning router $GATEWAY"
+  CREATE_SPINNER "Scanning router $GATEWAY"
   if [ "$ROUTER_OS_DETECT" = "1" ]; then
     nmap -O $NMAP_TIMING --host-timeout 120s -oA "$RUN/router" "$GATEWAY" >/dev/null 2>&1
   else
@@ -257,7 +256,7 @@ fi
 # ----------------------- PHASE: HOST DISCOVERY ------------------------------
 LED STAGE2
 say "Discovering hosts"
-spin_up "ARP/ping sweep $ACCESS_CIDR"
+CREATE_SPINNER "ARP/ping sweep $ACCESS_CIDR"
 # On a local segment, nmap uses ARP for discovery: reliable even when ICMP is
 # filtered. We scan the whole access subnet derived from our own lease.
 nmap -sn $NMAP_TIMING -oA "$RUN/discovery" "$IP/$PREFIX" >/dev/null 2>&1
@@ -271,7 +270,7 @@ say "$UPCOUNT hosts up"
 # --------------------- PHASE: SERVICE / PORT SCAN ---------------------------
 LED STAGE3
 if [ "$UPCOUNT" -gt 0 ]; then
-  spin_up "Port/service scan x$UPCOUNT"
+  CREATE_SPINNER "Port/service scan x$UPCOUNT"
   nmap -sV $NMAP_TIMING --top-ports "$TOP_PORTS" --host-timeout "$HOST_TIMEOUT" \
        $EXTRA_NMAP -iL "$RUN/up_hosts.txt" -oA "$RUN/services" >/dev/null 2>&1
   spin_down
@@ -294,7 +293,7 @@ say "Mapping VLANs"
 # and the tagged VID list on a trunk. Needs tcpdump.
 PASSIVE_TAGS=""
 if have tcpdump; then
-  spin_up "Listening ${PASSIVE_VLAN_SECS}s for 802.1Q"
+  CREATE_SPINNER "Listening ${PASSIVE_VLAN_SECS}s for 802.1Q"
   timeout "${PASSIVE_VLAN_SECS}s" tcpdump -e -nn -i eth0 -c 300 vlan 2>/dev/null \
     | grep -oE 'vlan [0-9]+' | awk '{print $2}' | sort -un > "$RUN/_tags.txt"
   spin_down
@@ -321,7 +320,7 @@ if [ "$SCAN_TAGGED_VLANS" = "1" ]; then
     echo "Tagged-VLAN scan (VIDs: $CANDIDATES):" >> "$VLANF"
     for vid in $CANDIDATES; do
       LED STAGE5
-      spin_up "VLAN $vid: lease + scan"
+      CREATE_SPINNER "VLAN $vid: lease + scan"
       ip link add link eth0 name "eth0.$vid" type vlan id "$vid" 2>/dev/null
       if ! ip link show "eth0.$vid" >/dev/null 2>&1; then
         # Interface never came into being: the 802.1Q kernel module is missing.

--- a/payloads/library/recon/jack_survey/README.md
+++ b/payloads/library/recon/jack_survey/README.md
@@ -1,0 +1,171 @@
+# Shark Jack Display - Jack Survey / Drop Validator
+
+Plug it into one wall jack and walk away with a per-drop verdict. It answers the
+four questions a site survey actually has to settle for every port:
+
+- **Does this port work?** carrier, negotiated speed and duplex.
+- **Where does it go?** LLDP/CDP switch name, model, and the exact port you are
+  patched into, plus the switch management IP.
+- **What VLAN is it?** the VLAN advertised by LLDP/CDP, with the access-subnet
+  CIDR as a fallback hint.
+- **Can users actually use it?** DHCP lease, gateway, DNS, and HTTP/HTTPS
+  reachability out to the internet.
+
+The run ends on a single tiered verdict (`PASS`, `PASS WITH NOTES`, `LIMITED`,
+`MISPATCH SUSPECTED`, or `FAIL`) so a non-engineer walking the floor can label
+each jack from the screen alone. This is the workhorse for infrastructure
+consulting and M&A due-diligence walk-throughs where you have to certify a room
+of drops fast.
+
+> **Authorized use only.** Run only on networks you own or are contracted to
+> assess, within the agreed scope and time window. The payload is mostly
+> passive: it listens, requests one DHCP lease, and sends a few small outbound
+> reachability probes to `INTERNET_TEST_HOST`. Nothing is exfiltrated: all output
+> stays on-device under `/root/loot/jack_survey/` until you retrieve it. See the
+> Legal and Disclaimer sections of the repository README.
+
+## How it works
+
+It runs quietest-first, the same opening order as the passive listener, so the
+jack is profiled before it ever announces an address:
+
+| Phase | What happens |
+|-------|--------------|
+| **Link** | brings `eth0` up and waits for carrier; reads negotiated speed/duplex |
+| **Passive discovery** | a passive `tcpdump` capture harvests LLDP/CDP (switch, port, VLAN, mgmt IP), passive ARP host count, DHCP servers seen, and spanning-tree presence, all before requesting an address |
+| **DHCP** | `NETMODE DHCP_CLIENT`, times the lease, derives IP / CIDR / gateway / DNS / domain; `nmap broadcast-dhcp-discover` adds lease time, NTP, PXE/TFTP, and WPAD/proxy detail |
+| **Expected-value checks** | optional: compares observed switch / port / VLAN / CIDR against the `EXPECTED_*` knobs to flag a mispatched drop |
+| **Internet tests** | DNS resolution plus HTTPS and HTTP reachability to `INTERNET_TEST_HOST` |
+| **VLAN visibility / reachability** | reads tagged VLANs out of the passive capture (a tag means the port is really a trunk); optionally tags onto each VLAN to test what is reachable. No scanning. See the VLAN section below |
+| **Report** | scores every check and writes the site-survey report |
+
+## Output (loot)
+
+`/root/loot/jack_survey/<UTC-timestamp>_<pid>/`:
+
+```
+summary.txt        <- verdict + per-check table + full detail (read this first)
+checks.tsv         <- machine-readable PASS/WARN/FAIL/MISMATCH/INFO rows
+passive.pcap       <- passive capture (open in Wireshark)
+lldp.txt / cdp.txt <- full neighbor decode
+arp_hosts.tsv      <- passively observed hosts (IP + MAC)
+dhcp.txt           <- nmap DHCP discover detail
+vlan_reach.txt     <- per-VLAN reachability probe (when PROBE_VLAN_REACH=1)
+dns_test.txt / https_test.txt / http_test.txt
+```
+
+`summary.txt` leads with the verdict and a `[STATUS] label  detail` check table,
+then breaks out physical link, DHCP, switch/port, VLAN (with a confidence note),
+passive observations, and internet results.
+
+## The verdict
+
+| Result | Meaning |
+|--------|---------|
+| `PASS` | link, DHCP, and internet all good |
+| `PASS WITH NOTES` | core checks passed, but warnings were recorded (e.g. sub-gig speed) |
+| `LIMITED` | link is up but DHCP failed, or DHCP works but the internet is blocked/limited |
+| `MISPATCH SUSPECTED` | an observed value does not match an `EXPECTED_*` you set |
+| `FAIL` | no physical link (check patch panel, switch port, cable, or jack termination) |
+
+## Configuration (top of [`payload.txt`](payload.txt))
+
+Leave the `EXPECTED_*` values blank for a generic survey; fill them in when you
+are validating a drop against a documented patch schedule and want mispatches
+flagged automatically.
+
+| Knob | Default | Notes |
+|------|---------|-------|
+| `LINK_WAIT_SECS` | `20` | seconds to wait for carrier before declaring the jack dead |
+| `DHCP_WAIT_SECS` | `30` | wait for a lease before reporting DHCP failed |
+| `PASSIVE_LISTEN_SECS` | `90` | passive LLDP/CDP capture window. LLDP/CDP announce every 30-60s, so >=90s catches a cycle |
+| `INTERNET_TEST_HOST` | `example.com` | DNS + HTTP/HTTPS reachability target (RFC 2606 reserved documentation domain) |
+| `EXPECTED_SWITCH` | `""` | expected LLDP/CDP switch name; mismatch flags a mispatch |
+| `EXPECTED_PORT` | `""` | expected switch port ID |
+| `EXPECTED_VLAN` | `""` | expected VLAN ID |
+| `EXPECTED_CIDR` | `""` | expected access-subnet CIDR, e.g. `10.20.30.0/24` |
+| `EXPECTED_SPEED_MIN` | `1000` | minimum Mbps; below this is a `WARN`. Empty disables the check |
+| `EXPECTED_DUPLEX` | `full` | expected duplex; mismatch is a `WARN`. Empty disables the check |
+| `PROBE_VLAN_REACH` | `0` | `1` = actively test which VLANs are *reachable* (tag on, try DHCP + gateway ping, tear down). Active VLAN tagging; authorized scope only |
+| `VLAN_PROBE_IDS` | `""` | extra VIDs to test for reachability even if no tagged frames were seen, e.g. `"99 200"` |
+| `VLAN_DHCP_WAIT` | `6` | per-VLAN DHCP timeout (seconds) during the reach probe |
+| `LOOT_BASE` | `/root/loot/jack_survey` | where loot lands |
+
+Note: `EXPECTED_SPEED_MIN` and `EXPECTED_DUPLEX` are checked even in generic mode,
+so a 100 Mbps or half-duplex drop is flagged `PASS WITH NOTES` even when no
+switch/port/VLAN is set. Blank either one to silence it.
+
+## Requirements
+
+- **`tcpdump`** for passive LLDP/CDP discovery (not on stock firmware:
+  `opkg update && opkg install tcpdump`). Without it, link/DHCP/internet still
+  run and switch identity is simply recorded as "not advertised".
+- **`nmap`** (ships on the device) for the detailed DHCP offer; optional.
+- **`nslookup`** and **`wget`** or **`curl`** for the DNS/internet tests. Each
+  check degrades gracefully to "unknown" if its tool is missing.
+- **`ip`** and **`udhcpc`** (busybox, on the device) are only used by the opt-in
+  VLAN reach probe; `ping` is used for the gateway check. Without them the probe
+  records "skipped" and everything else still runs.
+
+## On the VLAN reading
+
+A normal **access port** strips the 802.1Q tag before the frame reaches the
+device, so the access VLAN *ID* is not directly observable from the jack. The
+report is honest about this: if LLDP/CDP advertised a VLAN it is reported with
+high confidence; otherwise the verdict falls back to the access-subnet CIDR as a
+subnet hint and labels the VLAN confidence "low".
+
+Beyond the access VLAN, the payload also reports the **port mode**, which is
+where misconfigured drops give themselves away:
+
+- **Visibility (passive, always on, free).** The opening passive capture runs
+  with no address on the wire. An access port strips tags, so *any* tagged
+  802.1Q frame in that capture means the port is actually a **trunk**. The report
+  lists every tagged VLAN it saw and labels the port `access` or `trunk`
+  accordingly. This is the cheap, zero-risk tell for a jack that is documented as
+  an access port but was left trunking, or carries a voice VLAN, or sits behind a
+  port-based routing rule that bridges VLANs it should not.
+- **Reachability (opt-in, `PROBE_VLAN_REACH=1`).** For each VLAN it saw (plus any
+  you list in `VLAN_PROBE_IDS`), it brings up an `eth0.<vid>` sub-interface, asks
+  for a short DHCP lease, records the CIDR and gateway, pings the gateway once,
+  then tears the sub-interface down. That answers "which other VLANs can this
+  jack actually *reach*" end to end. A lease on a VLAN you did not expect, or a
+  reachable gateway across VLANs, is exactly the symptom of a port-based routing
+  rule or a CatOS/NXOS trunk-default mismatch.
+
+Crucially, jack_survey **never scans** the other VLANs: no host sweep, no port
+scan. Visibility is read from the capture it already took; reachability is a
+single DHCP request and one gateway ping per VLAN. Both report as `INFO`, so they
+enrich the survey without flipping the pass/fail verdict (a tagged voice VLAN is
+common and not, on its own, a fault). If you want it louder, set an
+`EXPECTED_VLAN` and read the tagged-VLAN list against it.
+
+> The reach probe is active VLAN tagging and is the **last** step in the run, on
+> purpose: it can briefly repoint the device's default route while a sub-interface
+> is up (it restores `eth0`'s route afterward, best-effort). Leave
+> `PROBE_VLAN_REACH=0` unless the engagement authorizes tagging onto other VLANs.
+
+## LED / screen cues
+
+`SETUP` -> `SPECIAL` (waiting for link) -> `STAGE1` passive discovery -> `STAGE2`
+DHCP -> `STAGE3` internet tests -> `STAGE4` VLAN reach probe (only when
+`PROBE_VLAN_REACH=1`) -> `CLEANUP` (writing report) -> verdict LED. A green
+`FINISH` means `PASS` / `PASS WITH NOTES`; amber `SPECIAL` means `LIMITED` or
+`MISPATCH SUSPECTED`; red `FAIL` means no link. The final `ALERT` carries the
+verdict, the leased IP, and the negotiated speed/duplex.
+
+## Notes
+
+- **Walk-the-floor workflow**: leave all `EXPECTED_*` blank to certify whatever a
+  jack happens to be, or paste a row from the patch schedule into the
+  `EXPECTED_*` knobs to have the device call out mispatched cabling for you.
+- **Trunk-on-an-access-jack is free to catch**: the port-mode line flags a jack
+  that is really trunking even with `PROBE_VLAN_REACH` off, since it is read from
+  the passive capture. Turn the reach probe on when you need to know *which*
+  VLANs a misconfigured port actually bridges onto (the port-based routing rule
+  / CatOS-to-NXOS trunk-default class of bug).
+- **Works on dead and NAC'd drops too**: no carrier ends in a clean `FAIL` with a
+  remediation hint; link-up-but-no-lease (802.1X / NAC / no DHCP) reports
+  `LIMITED` rather than hanging.
+- A run is roughly `PASSIVE_LISTEN_SECS` plus DHCP and probe time (about two to
+  three minutes on defaults), so a battery charge covers a long corridor of jacks.

--- a/payloads/library/recon/jack_survey/README.md
+++ b/payloads/library/recon/jack_survey/README.md
@@ -21,8 +21,7 @@ of drops fast.
 > assess, within the agreed scope and time window. The payload is mostly
 > passive: it listens, requests one DHCP lease, and sends a few small outbound
 > reachability probes to `INTERNET_TEST_HOST`. Nothing is exfiltrated: all output
-> stays on-device under `/root/loot/jack_survey/` until you retrieve it. See the
-> Legal and Disclaimer sections of the repository README.
+> stays on-device under `/root/loot/jack_survey/` until you retrieve it.
 
 ## How it works
 

--- a/payloads/library/recon/jack_survey/payload.txt
+++ b/payloads/library/recon/jack_survey/payload.txt
@@ -3,8 +3,9 @@
 #  Title:       Jack Survey / Drop Validator (Shark Jack Display)
 #  Author:      Brent Mills
 #  Target:      A single authorized wired wall jack / drop to validate.
-#  Category:    admin / site-survey / troubleshooting
+#  Category:    recon / admin / site-survey / troubleshooting
 #  Version:     1.1
+#  Firmware:    Tested on Shark Jack Display 1.0.1
 # ----------------------------------------------------------------------------
 #  WHAT IT DOES
 #    Validates one Ethernet wall jack end to end and answers the four

--- a/payloads/library/recon/jack_survey/payload.txt
+++ b/payloads/library/recon/jack_survey/payload.txt
@@ -1,0 +1,626 @@
+#!/bin/bash
+# ============================================================================
+#  Title:       Jack Survey / Drop Validator (Shark Jack Display)
+#  Author:      Brent Mills
+#  Target:      A single authorized wired wall jack / drop to validate.
+#  Category:    admin / site-survey / troubleshooting
+#  Version:     1.1
+# ----------------------------------------------------------------------------
+#  WHAT IT DOES
+#    Validates one Ethernet wall jack end to end and answers the four
+#    questions a site survey actually needs:
+#      - Does this port work? .. carrier, negotiated speed/duplex.
+#      - Where does it go? ..... LLDP/CDP switch name, model, and the PORT
+#                                you are patched into; switch management IP.
+#      - What VLAN is it? ...... VLAN advertised by LLDP/CDP, with the access
+#                                subnet CIDR as a fallback hint.
+#      - Can users use it? ..... DHCP lease, gateway, DNS, and HTTP/HTTPS
+#                                reachability out to the internet.
+#    Optionally compares what it observes against EXPECTED_* values to flag a
+#    mispatched drop (wrong switch / port / VLAN / subnet), then writes a site-
+#    survey report plus raw artifacts to loot.
+#
+#  AUTHORIZATION
+#    Mostly passive, plus a DHCP request and a few small outbound reachability
+#    probes to INTERNET_TEST_HOST. Run on networks you own or are contracted to
+#    assess, within the agreed scope and time window. Nothing is exfiltrated:
+#    all output stays on-device in /root/loot until you pull it.
+# ============================================================================
+
+# ------------------------------- CONFIG -------------------------------------
+LINK_WAIT_SECS=20
+DHCP_WAIT_SECS=30
+PASSIVE_LISTEN_SECS=90
+INTERNET_TEST_HOST="example.com"
+LOOT_BASE="/root/loot/jack_survey"
+
+# Optional expected values. Leave blank for generic survey mode.
+EXPECTED_SWITCH=""
+EXPECTED_PORT=""
+EXPECTED_VLAN=""
+EXPECTED_CIDR=""
+EXPECTED_SPEED_MIN="1000"       # Mbps. Empty disables speed check.
+EXPECTED_DUPLEX="full"          # full/half. Empty disables duplex check.
+
+# VLAN visibility / reachability. This is a DIAGNOSTIC, not a scanner: it tells
+# you which VLANs this jack can see and reach, never what lives on them.
+#   - Visibility is free and always on: tagged 802.1Q frames in the passive
+#     capture mean the port is really a trunk (an access port strips tags).
+#   - Reachability is opt-in: for each VLAN it tags onto eth0.<vid>, tries a
+#     short DHCP lease, notes CIDR/gateway, pings the gateway once, tears down.
+#     No host or port scanning of the other VLAN. Authorized scope only.
+PROBE_VLAN_REACH=0              # 1 = actively test which VLANs are reachable
+VLAN_PROBE_IDS=""              # extra VIDs to test even if not seen, e.g. "99 200"
+VLAN_DHCP_WAIT=6               # per-VLAN DHCP timeout (s) during the reach probe
+# ----------------------------------------------------------------------------
+
+say()  { SCREEN_WRITE "$*" 2>/dev/null; }
+glow() { LED "$@" 2>/dev/null; }
+have() { command -v "$1" >/dev/null 2>&1; }
+spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
+spin_down() { STOP_SPINNER 2>/dev/null; }
+
+ip_to_int() { local IFS=.; set -- $1; echo $(( ($1<<24)|($2<<16)|($3<<8)|$4 )); }
+int_to_ip() { local i=$1; echo "$(((i>>24)&255)).$(((i>>16)&255)).$(((i>>8)&255)).$((i&255))"; }
+mask_for()  { local p=$1; echo $(( (0xFFFFFFFF << (32-p)) & 0xFFFFFFFF )); }
+network_cidr() {
+  local ip=$1 p=$2 m
+  [ -z "$ip" ] || [ -z "$p" ] && return
+  m=$(mask_for "$p")
+  echo "$(int_to_ip $(( $(ip_to_int "$ip") & m )))/$p"
+}
+
+# Tagged VLAN IDs observed in the passive capture. A normal access port strips
+# 802.1Q tags, so anything here means the port is actually a trunk. <pcap>
+vlans_in_pcap() {
+  tcpdump -e -nn -r "$1" vlan 2>/dev/null \
+    | grep -oE 'vlan [0-9]+' | awk '{print $2}' | sort -un | tr '\n' ' '
+}
+
+get_link_state() {
+  cat /sys/class/net/eth0/carrier 2>/dev/null | grep -q 1 && echo "UP" || echo "DOWN"
+}
+
+get_speed() {
+  cat /sys/class/net/eth0/speed 2>/dev/null
+}
+
+get_duplex() {
+  cat /sys/class/net/eth0/duplex 2>/dev/null | tr 'A-Z' 'a-z'
+}
+
+lldp_field() {
+  awk -v lbl="$2" '
+    index($0,lbl) {
+      rest=substr($0,index($0,lbl)); val=""
+      if (match(rest,/: /)) val=substr(rest,RSTART+2)
+      if (val ~ /^[ \t]*$/) getline val
+      gsub(/^[ \t]+|[ \t]+$/,"",val)
+      sub(/^Subtype[^:]*: /,"",val)
+      print val
+      exit
+    }' "$1" 2>/dev/null
+}
+
+dhcp_field() {
+  grep -iE "$2" "$1" 2>/dev/null | head -1 | sed 's/^[^:]*: *//' | sed 's/^[ \t|]*//; s/[ \t]*$//'
+}
+
+contains_ci() {
+  echo "$1" | tr 'A-Z' 'a-z' | grep -q "$(echo "$2" | tr 'A-Z' 'a-z')"
+}
+
+record_check() {
+  # record_check <status> <label> <detail>
+  printf "%s\t%s\t%s\n" "$1" "$2" "$3" >> "$RUN/checks.tsv"
+}
+
+# ------------------------------ SETUP ---------------------------------------
+glow SETUP
+CLEAR_SCREEN 2>/dev/null
+say "Jack Survey"
+say "Waiting for link"
+
+RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
+mkdir -p "$RUN"
+REPORT="$RUN/summary.txt"
+: > "$RUN/checks.tsv"
+
+ip link set eth0 up 2>/dev/null
+
+# ------------------------------ LINK ----------------------------------------
+glow SPECIAL
+LINK="DOWN"
+
+for _ in $(seq 1 "$LINK_WAIT_SECS"); do
+  LINK=$(get_link_state)
+  [ "$LINK" = "UP" ] && break
+  sleep 1
+done
+
+SPEED=$(get_speed)
+DUPLEX=$(get_duplex)
+
+if [ "$LINK" = "UP" ]; then
+  record_check "PASS" "Physical link" "Carrier detected"
+else
+  record_check "FAIL" "Physical link" "No carrier detected"
+fi
+
+if [ -n "$EXPECTED_SPEED_MIN" ] && [ -n "$SPEED" ] && [ "$SPEED" -gt 0 ] 2>/dev/null; then
+  if [ "$SPEED" -ge "$EXPECTED_SPEED_MIN" ]; then
+    record_check "PASS" "Speed" "${SPEED} Mbps >= expected ${EXPECTED_SPEED_MIN} Mbps"
+  else
+    record_check "WARN" "Speed" "${SPEED} Mbps < expected ${EXPECTED_SPEED_MIN} Mbps"
+  fi
+fi
+
+if [ -n "$EXPECTED_DUPLEX" ] && [ -n "$DUPLEX" ]; then
+  if [ "$DUPLEX" = "$EXPECTED_DUPLEX" ]; then
+    record_check "PASS" "Duplex" "$DUPLEX"
+  else
+    record_check "WARN" "Duplex" "observed $DUPLEX, expected $EXPECTED_DUPLEX"
+  fi
+fi
+
+if [ "$LINK" != "UP" ]; then
+  glow FAIL
+  say "Link: DOWN"
+  say "No carrier"
+
+  {
+    echo "=========================================================="
+    echo " SHARK JACK DISPLAY - JACK SURVEY / DROP VALIDATOR"
+    echo "=========================================================="
+    echo " Run time : $(date -u '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null)"
+    echo ""
+    echo "---- PHYSICAL LINK ---------------------------------------"
+    echo " Link   : DOWN"
+    echo " Speed  : unknown"
+    echo " Duplex : unknown"
+    echo ""
+    echo "---- RESULT ----------------------------------------------"
+    echo " Status : FAIL"
+    echo " Reason : no physical link detected"
+    echo " Action : check patch panel, switch port, cable, or jack termination"
+    echo "=========================================================="
+  } > "$REPORT"
+
+  ALERT "Jack Survey FAIL: no link" 8 2>/dev/null
+  exit 0
+fi
+
+say "Link: UP"
+say "${SPEED:-?} Mbps ${DUPLEX:-?}"
+
+# --------------------------- PASSIVE DISCOVERY -------------------------------
+L_NAME="-"; L_PORT="-"; L_DESC="-"; L_MGMT="-"; L_VLAN="-"
+C_DEV="-"; C_PLAT="-"; C_PORT="-"; C_NVLAN="-"; C_ADDR="-"
+DHCP_SRV_SEEN="-"; STP_SEEN="not seen"; ARPN=0
+
+if have tcpdump; then
+  glow STAGE1
+  say "Passive discovery"
+  spin_up "LLDP/CDP/DHCP"
+
+  PCAP="$RUN/passive.pcap"
+  timeout "${PASSIVE_LISTEN_SECS}s" tcpdump -i eth0 -s 0 -w "$PCAP" 2>/dev/null
+
+  tcpdump -nn -v -r "$PCAP" 'ether proto 0x88cc' 2>/dev/null > "$RUN/lldp.txt"
+  tcpdump -nn -v -r "$PCAP" 'ether host 01:00:0c:cc:cc:cc' 2>/dev/null > "$RUN/cdp.txt"
+
+  L_NAME=$(lldp_field "$RUN/lldp.txt" 'System Name TLV')
+  L_PORT=$(lldp_field "$RUN/lldp.txt" 'Port ID TLV')
+  L_DESC=$(lldp_field "$RUN/lldp.txt" 'System Description TLV')
+  L_MGMT=$(grep -i 'Management Address' "$RUN/lldp.txt" 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+  L_VLAN=$(grep -iE 'PVID|Port VLAN ID' "$RUN/lldp.txt" 2>/dev/null | grep -oE '[0-9]+' | tail -1)
+
+  C_DEV=$(grep -i 'Device-ID' "$RUN/cdp.txt" 2>/dev/null | head -1 | sed "s/.*: '//; s/'.*//")
+  C_PLAT=$(grep -i 'Platform' "$RUN/cdp.txt" 2>/dev/null | head -1 | sed "s/.*: '//; s/'.*//")
+  C_PORT=$(grep -i 'Port-ID' "$RUN/cdp.txt" 2>/dev/null | head -1 | sed "s/.*: '//; s/'.*//")
+  C_NVLAN=$(grep -i 'Native VLAN' "$RUN/cdp.txt" 2>/dev/null | head -1 | grep -oE '[0-9]+' | head -1)
+  C_ADDR=$(grep -iA2 'Address' "$RUN/cdp.txt" 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+
+  tcpdump -nn -e -r "$PCAP" arp 2>/dev/null | awk '
+    {
+      mac=""
+      for (i=1;i<=NF;i++) if (mac=="" && $i ~ /^([0-9a-f]{2}:){5}[0-9a-f]{2}$/) mac=$i
+      for (i=1;i<=NF;i++) {
+        if ($i=="tell")  { ip=$(i+1); gsub(/[,:]$/,"",ip); if (ip ~ /^[0-9]+\./ && mac!="") print ip"\t"mac }
+        if ($i=="is-at") { ip=$(i-1); gsub(/[,:]$/,"",ip); m=$(i+1); gsub(/[,:]$/,"",m); if (ip ~ /^[0-9]+\./ && m ~ /:/) print ip"\t"m }
+      }
+    }' | sort -u > "$RUN/arp_hosts.tsv"
+
+  ARPN=$(wc -l < "$RUN/arp_hosts.tsv" 2>/dev/null | tr -d ' ')
+  [ -z "$ARPN" ] && ARPN=0
+
+  DHCP_SRV_SEEN=$(tcpdump -nn -r "$PCAP" '(udp port 67 or udp port 68)' 2>/dev/null \
+    | grep -oiE 'Server-ID Option[^,]*[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' \
+    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | sort -u | tr '\n' ' ')
+  [ -z "$DHCP_SRV_SEEN" ] && DHCP_SRV_SEEN="-"
+
+  STP_TMP=$(tcpdump -nn -r "$PCAP" 'stp' 2>/dev/null | head -1)
+  [ -n "$STP_TMP" ] && STP_SEEN="present"
+
+  spin_down
+else
+  echo "tcpdump not installed; passive LLDP/CDP discovery skipped." > "$RUN/passive_skipped.txt"
+  record_check "WARN" "Passive discovery" "tcpdump missing; LLDP/CDP skipped"
+fi
+
+SWITCH="${L_NAME:-$C_DEV}"
+PORT="${L_PORT:-$C_PORT}"
+OBS_VLAN="${L_VLAN:-$C_NVLAN}"
+MGMT="${L_MGMT:-$C_ADDR}"
+
+[ -n "$SWITCH" ] && [ "$SWITCH" != "-" ] && record_check "PASS" "Switch identity" "$SWITCH" || record_check "INFO" "Switch identity" "not advertised"
+[ -n "$PORT" ] && [ "$PORT" != "-" ] && record_check "PASS" "Switch port" "$PORT" || record_check "INFO" "Switch port" "not advertised"
+[ -n "$OBS_VLAN" ] && [ "$OBS_VLAN" != "-" ] && record_check "PASS" "VLAN advertised" "$OBS_VLAN" || record_check "INFO" "VLAN advertised" "not advertised"
+
+# ------------------------------- DHCP ---------------------------------------
+glow STAGE2
+say "DHCP request"
+NETMODE DHCP_CLIENT 2>/dev/null
+WAIT_FOR_LINK 2>/dev/null
+
+DHCP_START=$(date +%s 2>/dev/null)
+IP=""; PREFIX=""
+
+for _ in $(seq 1 "$DHCP_WAIT_SECS"); do
+  line=$(ip -o -4 addr show eth0 2>/dev/null | awk '{print $4}' | head -1)
+  if [ -n "$line" ]; then
+    IP=${line%/*}
+    PREFIX=${line#*/}
+    break
+  fi
+  sleep 1
+done
+
+DHCP_END=$(date +%s 2>/dev/null)
+DHCP_SECS=$((DHCP_END - DHCP_START))
+
+GATEWAY=$(ip route 2>/dev/null | awk '/default/{print $3; exit}')
+CIDR=$(network_cidr "$IP" "$PREFIX")
+DNS=$(grep -h nameserver /tmp/resolv.conf.auto /etc/resolv.conf 2>/dev/null | awk '{print $2}' | sort -u | tr '\n' ' ')
+DOMAIN=$(grep -hE '^(search|domain)' /tmp/resolv.conf.auto /etc/resolv.conf 2>/dev/null | awk '{print $2}' | head -1)
+
+DHCP_RESULT="FAILED"
+[ -n "$IP" ] && DHCP_RESULT="SUCCESS"
+
+if [ "$DHCP_RESULT" = "SUCCESS" ]; then
+  record_check "PASS" "DHCP" "$IP/$PREFIX in ${DHCP_SECS}s"
+  say "DHCP: OK"
+  say "$IP/$PREFIX"
+else
+  record_check "WARN" "DHCP" "No lease after ${DHCP_WAIT_SECS}s"
+  say "DHCP: FAILED"
+fi
+
+DHCP_SERVER="$DHCP_SRV_SEEN"
+LEASE="-"; NTP="-"; TFTP="-"; WPAD="-"
+
+if have nmap; then
+  nmap --script broadcast-dhcp-discover -e eth0 2>/dev/null > "$RUN/dhcp.txt"
+  DHCP_SERVER_NMAP=$(dhcp_field "$RUN/dhcp.txt" 'Server Identifier|DHCP Server Identifier')
+  [ -n "$DHCP_SERVER_NMAP" ] && DHCP_SERVER="$DHCP_SERVER_NMAP"
+  LEASE=$(dhcp_field "$RUN/dhcp.txt" 'Lease Time')
+  NTP=$(dhcp_field "$RUN/dhcp.txt" 'NTP Server')
+  TFTP=$(dhcp_field "$RUN/dhcp.txt" 'TFTP|Bootfile|Boot File')
+  WPAD=$(dhcp_field "$RUN/dhcp.txt" 'WPAD|Proxy')
+else
+  echo "nmap not installed; detailed DHCP discover skipped." > "$RUN/dhcp_skipped.txt"
+  record_check "INFO" "DHCP details" "nmap missing; full offer not collected"
+fi
+
+# -------------------------- EXPECTED VALUE CHECKS ----------------------------
+if [ -n "$EXPECTED_SWITCH" ]; then
+  if [ -n "$SWITCH" ] && [ "$SWITCH" != "-" ] && contains_ci "$SWITCH" "$EXPECTED_SWITCH"; then
+    record_check "PASS" "Expected switch" "observed $SWITCH"
+  else
+    record_check "MISMATCH" "Expected switch" "expected $EXPECTED_SWITCH, observed ${SWITCH:--}"
+  fi
+fi
+
+if [ -n "$EXPECTED_PORT" ]; then
+  if [ -n "$PORT" ] && [ "$PORT" != "-" ] && contains_ci "$PORT" "$EXPECTED_PORT"; then
+    record_check "PASS" "Expected port" "observed $PORT"
+  else
+    record_check "MISMATCH" "Expected port" "expected $EXPECTED_PORT, observed ${PORT:--}"
+  fi
+fi
+
+if [ -n "$EXPECTED_VLAN" ]; then
+  if [ -n "$OBS_VLAN" ] && [ "$OBS_VLAN" = "$EXPECTED_VLAN" ]; then
+    record_check "PASS" "Expected VLAN" "observed $OBS_VLAN"
+  elif [ -n "$OBS_VLAN" ] && [ "$OBS_VLAN" != "-" ]; then
+    record_check "MISMATCH" "Expected VLAN" "expected $EXPECTED_VLAN, observed $OBS_VLAN"
+  else
+    record_check "WARN" "Expected VLAN" "expected $EXPECTED_VLAN, but VLAN not advertised on this access port"
+  fi
+fi
+
+if [ -n "$EXPECTED_CIDR" ]; then
+  if [ -n "$CIDR" ] && [ "$CIDR" = "$EXPECTED_CIDR" ]; then
+    record_check "PASS" "Expected CIDR" "observed $CIDR"
+  else
+    record_check "MISMATCH" "Expected CIDR" "expected $EXPECTED_CIDR, observed ${CIDR:--}"
+  fi
+fi
+
+# --------------------------- INTERNET TESTS ---------------------------------
+DNS_RESULT="not tested"
+HTTPS_RESULT="not tested"
+HTTP_RESULT="not tested"
+
+if [ -n "$IP" ]; then
+  glow STAGE3
+  say "Internet tests"
+
+  if have nslookup; then
+    nslookup "$INTERNET_TEST_HOST" > "$RUN/dns_test.txt" 2>&1
+    grep -qiE 'Address|Name:' "$RUN/dns_test.txt" && DNS_RESULT="PASS" || DNS_RESULT="FAIL"
+  else
+    echo "nslookup missing" > "$RUN/dns_test.txt"
+    DNS_RESULT="unknown"
+  fi
+
+  if have wget; then
+    wget -q --spider --timeout=8 "https://$INTERNET_TEST_HOST" > "$RUN/https_test.txt" 2>&1
+    [ "$?" -eq 0 ] && HTTPS_RESULT="PASS" || HTTPS_RESULT="FAIL"
+    wget -q --spider --timeout=8 "http://$INTERNET_TEST_HOST" > "$RUN/http_test.txt" 2>&1
+    [ "$?" -eq 0 ] && HTTP_RESULT="PASS" || HTTP_RESULT="FAIL"
+  elif have curl; then
+    curl -Is -m 8 "https://$INTERNET_TEST_HOST" > "$RUN/https_test.txt" 2>&1
+    [ "$?" -eq 0 ] && HTTPS_RESULT="PASS" || HTTPS_RESULT="FAIL"
+    curl -Is -m 8 "http://$INTERNET_TEST_HOST" > "$RUN/http_test.txt" 2>&1
+    [ "$?" -eq 0 ] && HTTP_RESULT="PASS" || HTTP_RESULT="FAIL"
+  else
+    echo "wget/curl missing" > "$RUN/http_https_skipped.txt"
+    HTTPS_RESULT="unknown"
+    HTTP_RESULT="unknown"
+  fi
+
+  [ "$DNS_RESULT" = "PASS" ] && record_check "PASS" "DNS resolution" "$INTERNET_TEST_HOST" || record_check "WARN" "DNS resolution" "$DNS_RESULT"
+  if [ "$HTTPS_RESULT" = "PASS" ] || [ "$HTTP_RESULT" = "PASS" ]; then
+    record_check "PASS" "Internet reachability" "HTTPS=$HTTPS_RESULT HTTP=$HTTP_RESULT"
+  else
+    record_check "WARN" "Internet reachability" "HTTPS=$HTTPS_RESULT HTTP=$HTTP_RESULT"
+  fi
+fi
+
+# ---------------------- VLAN VISIBILITY / REACHABILITY ----------------------
+# Passive visibility (free): tagged VLANs in the capture == this jack is a trunk,
+# not the access port it may be documented as. Optional reach probe: tag onto
+# each VLAN, see if a lease/gateway answers. No host or port scanning either way.
+VLANS_SEEN="-"
+PORT_MODE="access (no tagged VLANs visible)"
+REACH_VLANS="-"
+: > "$RUN/vlan_reach.txt"
+
+if [ -s "$PCAP" ] && have tcpdump; then
+  VLANS_SEEN=$(vlans_in_pcap "$PCAP")
+  [ -z "$VLANS_SEEN" ] && VLANS_SEEN="-"
+fi
+
+if [ "$VLANS_SEEN" != "-" ]; then
+  PORT_MODE="trunk (tagged VLANs visible)"
+  record_check "INFO" "Port mode" "trunk - tagged VLANs visible: $VLANS_SEEN"
+else
+  record_check "INFO" "Port mode" "access - no tagged VLANs visible"
+fi
+
+if [ "$PROBE_VLAN_REACH" = "1" ]; then
+  glow STAGE4
+  say "VLAN reach probe"
+  if have ip && have udhcpc; then
+    spin_up "Tagging VLANs (no scan)"
+    lsmod 2>/dev/null | grep -q 8021q || modprobe 8021q 2>/dev/null
+    # Restore eth0's default route afterwards: udhcpc on a sub-iface repoints it.
+    ORIG_DEFAULT=$(ip route show default 2>/dev/null | head -1)
+    PROBE_IDS=$(printf '%s %s\n' "$VLANS_SEEN" "$VLAN_PROBE_IDS" \
+                | tr ' ' '\n' | grep -E '^[0-9]+$' | sort -un | tr '\n' ' ')
+    REACHED=""
+    if [ -z "$PROBE_IDS" ]; then
+      record_check "INFO" "VLAN reachability" "no candidate VLANs to probe"
+    else
+      for vid in $PROBE_IDS; do
+        ip link add link eth0 name "eth0.$vid" type vlan id "$vid" 2>/dev/null
+        if ! ip link show "eth0.$vid" >/dev/null 2>&1; then
+          echo " VLAN $vid : no 802.1Q sub-interface (kernel refused tag)" >> "$RUN/vlan_reach.txt"
+          continue
+        fi
+        ip link set "eth0.$vid" up 2>/dev/null
+        udhcpc -i "eth0.$vid" -n -q -t 3 -T "$VLAN_DHCP_WAIT" >/dev/null 2>&1
+        vline=$(ip -o -4 addr show "eth0.$vid" 2>/dev/null | awk '{print $4}' | head -1)
+        if [ -n "$vline" ]; then
+          vip=${vline%/*}; vp=${vline#*/}
+          vcidr=$(network_cidr "$vip" "$vp")
+          vgw=$(ip route 2>/dev/null | awk -v d="eth0.$vid" '/default/ && $0 ~ ("dev "d){print $3; exit}')
+          [ -z "$vgw" ] && vgw=$(echo "$vcidr" | sed 's,0/.*,1,')
+          gwping="no"
+          have ping && ping -c 1 -w 2 "$vgw" >/dev/null 2>&1 && gwping="yes"
+          echo " VLAN $vid : REACHABLE  lease $vip/$vp  net $vcidr  gw $vgw  gw-ping $gwping" >> "$RUN/vlan_reach.txt"
+          REACHED="$REACHED $vid"
+        else
+          echo " VLAN $vid : tagged OK, no DHCP lease (L2 permitted, no L3/DHCP answer)" >> "$RUN/vlan_reach.txt"
+        fi
+        ip link set "eth0.$vid" down 2>/dev/null
+        ip link del "eth0.$vid" 2>/dev/null
+      done
+      REACH_VLANS=$(echo "$REACHED" | sed 's/^ *//'); [ -z "$REACH_VLANS" ] && REACH_VLANS="-"
+      if [ "$REACH_VLANS" != "-" ]; then
+        record_check "INFO" "VLAN reachability" "reachable from this jack: $REACH_VLANS"
+      else
+        record_check "INFO" "VLAN reachability" "no probed VLANs reachable"
+      fi
+    fi
+    # Best-effort: put eth0's default route back if the probe stole it.
+    [ -n "$ORIG_DEFAULT" ] && ! ip route show default 2>/dev/null | grep -q . \
+      && ip route add $ORIG_DEFAULT 2>/dev/null
+    spin_down
+  else
+    record_check "INFO" "VLAN reachability" "ip/udhcpc missing; reach probe skipped"
+  fi
+fi
+
+# ------------------------------- SCORE --------------------------------------
+MIS=$(awk -F'\t' '$1=="MISMATCH"{c++} END{print c+0}' "$RUN/checks.tsv")
+WARN=$(awk -F'\t' '$1=="WARN"{c++} END{print c+0}' "$RUN/checks.tsv")
+FAIL=$(awk -F'\t' '$1=="FAIL"{c++} END{print c+0}' "$RUN/checks.tsv")
+
+RESULT="PASS"
+REASON="Link, DHCP, and internet checks passed."
+
+if [ "$FAIL" -gt 0 ]; then
+  RESULT="FAIL"
+  REASON="Physical link failed."
+elif [ "$MIS" -gt 0 ]; then
+  RESULT="MISPATCH SUSPECTED"
+  REASON="One or more observed values do not match expected survey values."
+elif [ "$DHCP_RESULT" != "SUCCESS" ]; then
+  RESULT="LIMITED"
+  REASON="Physical link is up, but DHCP failed."
+elif ! { [ "$HTTPS_RESULT" = "PASS" ] || [ "$HTTP_RESULT" = "PASS" ]; }; then
+  RESULT="LIMITED"
+  REASON="Link and DHCP work, but internet reachability is limited or blocked."
+elif [ "$WARN" -gt 0 ]; then
+  RESULT="PASS WITH NOTES"
+  REASON="Core jack checks passed, but warnings were recorded."
+fi
+
+VLAN_DISPLAY="$OBS_VLAN"
+VLAN_CONF="Unknown"
+if [ -n "$OBS_VLAN" ] && [ "$OBS_VLAN" != "-" ]; then
+  VLAN_CONF="High - advertised by LLDP/CDP"
+else
+  VLAN_DISPLAY="not visible on access port"
+  VLAN_CONF="Low - access ports strip 802.1Q tags; use CIDR as a subnet hint"
+fi
+
+# ------------------------------ REPORT --------------------------------------
+glow CLEANUP
+say "Writing report"
+
+{
+  echo "=========================================================="
+  echo " SHARK JACK DISPLAY - JACK SURVEY / DROP VALIDATOR"
+  echo "=========================================================="
+  echo " Run time : $(date -u '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null)"
+  echo " Loot     : $RUN"
+  echo ""
+  echo "---- RESULT ----------------------------------------------"
+  echo " Status   : $RESULT"
+  echo " Reason   : $REASON"
+  echo ""
+  echo "---- CHECK SUMMARY ---------------------------------------"
+  awk -F'\t' '{printf " [%s] %-24s %s\n", $1, $2, $3}' "$RUN/checks.tsv"
+  echo ""
+  echo "---- EXPECTED VALUES -------------------------------------"
+  echo " Switch       : ${EXPECTED_SWITCH:-not set}"
+  echo " Port         : ${EXPECTED_PORT:-not set}"
+  echo " VLAN         : ${EXPECTED_VLAN:-not set}"
+  echo " CIDR         : ${EXPECTED_CIDR:-not set}"
+  echo " Min speed    : ${EXPECTED_SPEED_MIN:-not set}"
+  echo " Duplex       : ${EXPECTED_DUPLEX:-not set}"
+  echo ""
+  echo "---- PHYSICAL LINK ---------------------------------------"
+  echo " Link         : $LINK"
+  echo " Speed        : ${SPEED:-unknown} Mbps"
+  echo " Duplex       : ${DUPLEX:-unknown}"
+  echo ""
+  echo "---- DHCP ------------------------------------------------"
+  echo " Result       : $DHCP_RESULT"
+  echo " Time         : ${DHCP_SECS:-unknown}s"
+  echo " IP           : ${IP:--}/${PREFIX:--}"
+  echo " CIDR         : ${CIDR:--}"
+  echo " Gateway      : ${GATEWAY:--}"
+  echo " DNS          : ${DNS:--}"
+  echo " Domain       : ${DOMAIN:--}"
+  echo " DHCP server  : ${DHCP_SERVER:--}"
+  echo " Lease time   : ${LEASE:--}"
+  echo " NTP          : ${NTP:--}"
+  echo " PXE / TFTP   : ${TFTP:--}"
+  echo " WPAD / proxy : ${WPAD:--}"
+  echo ""
+  echo "---- SWITCH / PORT ---------------------------------------"
+  echo " LLDP switch  : ${L_NAME:--}"
+  echo " LLDP port    : ${L_PORT:--}"
+  echo " LLDP desc    : ${L_DESC:--}"
+  echo " LLDP mgmt    : ${L_MGMT:--}"
+  echo " LLDP VLAN    : ${L_VLAN:--}"
+  echo ""
+  echo " CDP device   : ${C_DEV:--}"
+  echo " CDP platform : ${C_PLAT:--}"
+  echo " CDP port     : ${C_PORT:--}"
+  echo " CDP mgmt     : ${C_ADDR:--}"
+  echo " CDP VLAN     : ${C_NVLAN:--}"
+  echo ""
+  echo "---- VLAN ------------------------------------------------"
+  echo " VLAN         : $VLAN_DISPLAY"
+  echo " Confidence   : $VLAN_CONF"
+  echo " CIDR hint    : ${CIDR:--}"
+  echo " Note         : On a normal access port, the switch strips VLAN tags."
+  echo ""
+  echo "---- PORT MODE / VLAN VISIBILITY -------------------------"
+  echo " Port mode         : $PORT_MODE"
+  echo " Tagged VLANs seen : $VLANS_SEEN"
+  if [ -s "$RUN/vlan_reach.txt" ]; then
+    echo " Reach probe (tag on, DHCP + gw ping, no scan):"
+    sed 's/^/ /' "$RUN/vlan_reach.txt"
+  else
+    echo " Reachability      : not probed (set PROBE_VLAN_REACH=1)"
+  fi
+  echo " Note         : tagged VLANs on a jack documented as access usually mean"
+  echo "                a trunk, a voice VLAN, or a port-based routing rule."
+  echo "                Reachable VLANs show what this port is actually"
+  echo "                permitted onto, end to end."
+  echo ""
+  echo "---- PASSIVE OBSERVATIONS --------------------------------"
+  echo " ARP hosts seen      : $ARPN"
+  echo " DHCP servers seen   : ${DHCP_SRV_SEEN:--}"
+  echo " Spanning-tree       : $STP_SEEN"
+  echo ""
+  echo "---- INTERNET --------------------------------------------"
+  echo " Test host    : $INTERNET_TEST_HOST"
+  echo " DNS lookup   : $DNS_RESULT"
+  echo " HTTPS        : $HTTPS_RESULT"
+  echo " HTTP         : $HTTP_RESULT"
+  echo ""
+  echo "---- RAW ARTIFACTS ---------------------------------------"
+  echo " passive.pcap"
+  echo " lldp.txt / cdp.txt"
+  echo " arp_hosts.tsv"
+  echo " dhcp.txt"
+  echo " vlan_reach.txt"
+  echo " dns_test.txt / https_test.txt / http_test.txt"
+  echo " checks.tsv"
+  echo "=========================================================="
+} > "$REPORT"
+
+# ------------------------------- DISPLAY ------------------------------------
+CLEAR_SCREEN 2>/dev/null
+
+case "$RESULT" in
+  PASS|PASS\ WITH\ NOTES) glow FINISH ;;
+  LIMITED|MISPATCH\ SUSPECTED) glow SPECIAL ;;
+  *) glow FAIL ;;
+esac
+
+say "Jack: $RESULT"
+say "Link: ${SPEED:-?} ${DUPLEX:-?}"
+
+if [ -n "$IP" ]; then
+  say "IP: $IP/$PREFIX"
+else
+  say "DHCP: FAILED"
+fi
+
+[ -n "$SWITCH" ] && [ "$SWITCH" != "-" ] && say "Sw: $SWITCH"
+[ -n "$PORT" ] && [ "$PORT" != "-" ] && say "Port: $PORT"
+say "VLAN: $VLAN_DISPLAY"
+[ "$VLANS_SEEN" != "-" ] && say "Trunk VLANs: $VLANS_SEEN"
+[ "$REACH_VLANS" != "-" ] && say "Reach: $REACH_VLANS"
+say "Net: DNS $DNS_RESULT HTTPS $HTTPS_RESULT"
+
+ALERT "Jack Survey $RESULT: ${IP:-no DHCP}, ${SPEED:-?}Mbps ${DUPLEX:-?}" 12 2>/dev/null
+exit 0

--- a/payloads/library/recon/jack_survey/payload.txt
+++ b/payloads/library/recon/jack_survey/payload.txt
@@ -56,7 +56,6 @@ VLAN_DHCP_WAIT=6               # per-VLAN DHCP timeout (s) during the reach prob
 # ----------------------------------------------------------------------------
 
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-glow() { LED "$@" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
@@ -117,7 +116,7 @@ record_check() {
 }
 
 # ------------------------------ SETUP ---------------------------------------
-glow SETUP
+LED SETUP
 CLEAR_SCREEN 2>/dev/null
 say "Jack Survey"
 say "Waiting for link"
@@ -130,7 +129,7 @@ REPORT="$RUN/summary.txt"
 ip link set eth0 up 2>/dev/null
 
 # ------------------------------ LINK ----------------------------------------
-glow SPECIAL
+LED SPECIAL
 LINK="DOWN"
 
 for _ in $(seq 1 "$LINK_WAIT_SECS"); do
@@ -165,7 +164,7 @@ if [ -n "$EXPECTED_DUPLEX" ] && [ -n "$DUPLEX" ]; then
 fi
 
 if [ "$LINK" != "UP" ]; then
-  glow FAIL
+  LED FAIL
   say "Link: DOWN"
   say "No carrier"
 
@@ -200,7 +199,7 @@ C_DEV="-"; C_PLAT="-"; C_PORT="-"; C_NVLAN="-"; C_ADDR="-"
 DHCP_SRV_SEEN="-"; STP_SEEN="not seen"; ARPN=0
 
 if have tcpdump; then
-  glow STAGE1
+  LED STAGE1
   say "Passive discovery"
   spin_up "LLDP/CDP/DHCP"
 
@@ -259,7 +258,7 @@ MGMT="${L_MGMT:-$C_ADDR}"
 [ -n "$OBS_VLAN" ] && [ "$OBS_VLAN" != "-" ] && record_check "PASS" "VLAN advertised" "$OBS_VLAN" || record_check "INFO" "VLAN advertised" "not advertised"
 
 # ------------------------------- DHCP ---------------------------------------
-glow STAGE2
+LED STAGE2
 say "DHCP request"
 NETMODE DHCP_CLIENT 2>/dev/null
 WAIT_FOR_LINK 2>/dev/null
@@ -354,7 +353,7 @@ HTTPS_RESULT="not tested"
 HTTP_RESULT="not tested"
 
 if [ -n "$IP" ]; then
-  glow STAGE3
+  LED STAGE3
   say "Internet tests"
 
   if have nslookup; then
@@ -411,7 +410,7 @@ else
 fi
 
 if [ "$PROBE_VLAN_REACH" = "1" ]; then
-  glow STAGE4
+  LED STAGE4
   say "VLAN reach probe"
   if have ip && have udhcpc; then
     spin_up "Tagging VLANs (no scan)"
@@ -499,7 +498,7 @@ else
 fi
 
 # ------------------------------ REPORT --------------------------------------
-glow CLEANUP
+LED CLEANUP
 say "Writing report"
 
 {
@@ -602,9 +601,9 @@ say "Writing report"
 CLEAR_SCREEN 2>/dev/null
 
 case "$RESULT" in
-  PASS|PASS\ WITH\ NOTES) glow FINISH ;;
-  LIMITED|MISPATCH\ SUSPECTED) glow SPECIAL ;;
-  *) glow FAIL ;;
+  PASS|PASS\ WITH\ NOTES) LED FINISH ;;
+  LIMITED|MISPATCH\ SUSPECTED) LED SPECIAL ;;
+  *) LED FAIL ;;
 esac
 
 say "Jack: $RESULT"

--- a/payloads/library/recon/jack_survey/payload.txt
+++ b/payloads/library/recon/jack_survey/payload.txt
@@ -57,7 +57,6 @@ VLAN_DHCP_WAIT=6               # per-VLAN DHCP timeout (s) during the reach prob
 
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
-spin_down() { STOP_SPINNER 2>/dev/null; }
 
 ip_to_int() { local IFS=.; set -- $1; echo $(( ($1<<24)|($2<<16)|($3<<8)|$4 )); }
 int_to_ip() { local i=$1; echo "$(((i>>24)&255)).$(((i>>16)&255)).$(((i>>8)&255)).$((i&255))"; }
@@ -241,7 +240,7 @@ if have tcpdump; then
   STP_TMP=$(tcpdump -nn -r "$PCAP" 'stp' 2>/dev/null | head -1)
   [ -n "$STP_TMP" ] && STP_SEEN="present"
 
-  spin_down
+  STOP_SPINNER
 else
   echo "tcpdump not installed; passive LLDP/CDP discovery skipped." > "$RUN/passive_skipped.txt"
   record_check "WARN" "Passive discovery" "tcpdump missing; LLDP/CDP skipped"
@@ -456,7 +455,7 @@ if [ "$PROBE_VLAN_REACH" = "1" ]; then
     # Best-effort: put eth0's default route back if the probe stole it.
     [ -n "$ORIG_DEFAULT" ] && ! ip route show default 2>/dev/null | grep -q . \
       && ip route add $ORIG_DEFAULT 2>/dev/null
-    spin_down
+    STOP_SPINNER
   else
     record_check "INFO" "VLAN reachability" "ip/udhcpc missing; reach probe skipped"
   fi

--- a/payloads/library/recon/jack_survey/payload.txt
+++ b/payloads/library/recon/jack_survey/payload.txt
@@ -57,7 +57,6 @@ VLAN_DHCP_WAIT=6               # per-VLAN DHCP timeout (s) during the reach prob
 
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
-spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 
 ip_to_int() { local IFS=.; set -- $1; echo $(( ($1<<24)|($2<<16)|($3<<8)|$4 )); }
@@ -201,7 +200,7 @@ DHCP_SRV_SEEN="-"; STP_SEEN="not seen"; ARPN=0
 if have tcpdump; then
   LED STAGE1
   say "Passive discovery"
-  spin_up "LLDP/CDP/DHCP"
+  CREATE_SPINNER "LLDP/CDP/DHCP"
 
   PCAP="$RUN/passive.pcap"
   timeout "${PASSIVE_LISTEN_SECS}s" tcpdump -i eth0 -s 0 -w "$PCAP" 2>/dev/null
@@ -413,7 +412,7 @@ if [ "$PROBE_VLAN_REACH" = "1" ]; then
   LED STAGE4
   say "VLAN reach probe"
   if have ip && have udhcpc; then
-    spin_up "Tagging VLANs (no scan)"
+    CREATE_SPINNER "Tagging VLANs (no scan)"
     lsmod 2>/dev/null | grep -q 8021q || modprobe 8021q 2>/dev/null
     # Restore eth0's default route afterwards: udhcpc on a sub-iface repoints it.
     ORIG_DEFAULT=$(ip route show default 2>/dev/null | head -1)

--- a/payloads/library/recon/jack_survey/payload.txt
+++ b/payloads/library/recon/jack_survey/payload.txt
@@ -55,7 +55,6 @@ VLAN_PROBE_IDS=""              # extra VIDs to test even if not seen, e.g. "99 2
 VLAN_DHCP_WAIT=6               # per-VLAN DHCP timeout (s) during the reach probe
 # ----------------------------------------------------------------------------
 
-say()  { SCREEN_WRITE "$*" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
 ip_to_int() { local IFS=.; set -- $1; echo $(( ($1<<24)|($2<<16)|($3<<8)|$4 )); }
@@ -116,8 +115,8 @@ record_check() {
 # ------------------------------ SETUP ---------------------------------------
 LED SETUP
 CLEAR_SCREEN 2>/dev/null
-say "Jack Survey"
-say "Waiting for link"
+SCREEN_WRITE "Jack Survey"
+SCREEN_WRITE "Waiting for link"
 
 RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
 mkdir -p "$RUN"
@@ -163,8 +162,8 @@ fi
 
 if [ "$LINK" != "UP" ]; then
   LED FAIL
-  say "Link: DOWN"
-  say "No carrier"
+  SCREEN_WRITE "Link: DOWN"
+  SCREEN_WRITE "No carrier"
 
   {
     echo "=========================================================="
@@ -188,8 +187,8 @@ if [ "$LINK" != "UP" ]; then
   exit 0
 fi
 
-say "Link: UP"
-say "${SPEED:-?} Mbps ${DUPLEX:-?}"
+SCREEN_WRITE "Link: UP"
+SCREEN_WRITE "${SPEED:-?} Mbps ${DUPLEX:-?}"
 
 # --------------------------- PASSIVE DISCOVERY -------------------------------
 L_NAME="-"; L_PORT="-"; L_DESC="-"; L_MGMT="-"; L_VLAN="-"
@@ -198,7 +197,7 @@ DHCP_SRV_SEEN="-"; STP_SEEN="not seen"; ARPN=0
 
 if have tcpdump; then
   LED STAGE1
-  say "Passive discovery"
+  SCREEN_WRITE "Passive discovery"
   CREATE_SPINNER "LLDP/CDP/DHCP"
 
   PCAP="$RUN/passive.pcap"
@@ -257,7 +256,7 @@ MGMT="${L_MGMT:-$C_ADDR}"
 
 # ------------------------------- DHCP ---------------------------------------
 LED STAGE2
-say "DHCP request"
+SCREEN_WRITE "DHCP request"
 NETMODE DHCP_CLIENT 2>/dev/null
 WAIT_FOR_LINK 2>/dev/null
 
@@ -287,11 +286,11 @@ DHCP_RESULT="FAILED"
 
 if [ "$DHCP_RESULT" = "SUCCESS" ]; then
   record_check "PASS" "DHCP" "$IP/$PREFIX in ${DHCP_SECS}s"
-  say "DHCP: OK"
-  say "$IP/$PREFIX"
+  SCREEN_WRITE "DHCP: OK"
+  SCREEN_WRITE "$IP/$PREFIX"
 else
   record_check "WARN" "DHCP" "No lease after ${DHCP_WAIT_SECS}s"
-  say "DHCP: FAILED"
+  SCREEN_WRITE "DHCP: FAILED"
 fi
 
 DHCP_SERVER="$DHCP_SRV_SEEN"
@@ -352,7 +351,7 @@ HTTP_RESULT="not tested"
 
 if [ -n "$IP" ]; then
   LED STAGE3
-  say "Internet tests"
+  SCREEN_WRITE "Internet tests"
 
   if have nslookup; then
     nslookup "$INTERNET_TEST_HOST" > "$RUN/dns_test.txt" 2>&1
@@ -409,7 +408,7 @@ fi
 
 if [ "$PROBE_VLAN_REACH" = "1" ]; then
   LED STAGE4
-  say "VLAN reach probe"
+  SCREEN_WRITE "VLAN reach probe"
   if have ip && have udhcpc; then
     CREATE_SPINNER "Tagging VLANs (no scan)"
     lsmod 2>/dev/null | grep -q 8021q || modprobe 8021q 2>/dev/null
@@ -497,7 +496,7 @@ fi
 
 # ------------------------------ REPORT --------------------------------------
 LED CLEANUP
-say "Writing report"
+SCREEN_WRITE "Writing report"
 
 {
   echo "=========================================================="
@@ -604,21 +603,21 @@ case "$RESULT" in
   *) LED FAIL ;;
 esac
 
-say "Jack: $RESULT"
-say "Link: ${SPEED:-?} ${DUPLEX:-?}"
+SCREEN_WRITE "Jack: $RESULT"
+SCREEN_WRITE "Link: ${SPEED:-?} ${DUPLEX:-?}"
 
 if [ -n "$IP" ]; then
-  say "IP: $IP/$PREFIX"
+  SCREEN_WRITE "IP: $IP/$PREFIX"
 else
-  say "DHCP: FAILED"
+  SCREEN_WRITE "DHCP: FAILED"
 fi
 
-[ -n "$SWITCH" ] && [ "$SWITCH" != "-" ] && say "Sw: $SWITCH"
-[ -n "$PORT" ] && [ "$PORT" != "-" ] && say "Port: $PORT"
-say "VLAN: $VLAN_DISPLAY"
-[ "$VLANS_SEEN" != "-" ] && say "Trunk VLANs: $VLANS_SEEN"
-[ "$REACH_VLANS" != "-" ] && say "Reach: $REACH_VLANS"
-say "Net: DNS $DNS_RESULT HTTPS $HTTPS_RESULT"
+[ -n "$SWITCH" ] && [ "$SWITCH" != "-" ] && SCREEN_WRITE "Sw: $SWITCH"
+[ -n "$PORT" ] && [ "$PORT" != "-" ] && SCREEN_WRITE "Port: $PORT"
+SCREEN_WRITE "VLAN: $VLAN_DISPLAY"
+[ "$VLANS_SEEN" != "-" ] && SCREEN_WRITE "Trunk VLANs: $VLANS_SEEN"
+[ "$REACH_VLANS" != "-" ] && SCREEN_WRITE "Reach: $REACH_VLANS"
+SCREEN_WRITE "Net: DNS $DNS_RESULT HTTPS $HTTPS_RESULT"
 
 ALERT "Jack Survey $RESULT: ${IP:-no DHCP}, ${SPEED:-?}Mbps ${DUPLEX:-?}" 12 2>/dev/null
 exit 0

--- a/payloads/library/recon/net_map_exporter/README.md
+++ b/payloads/library/recon/net_map_exporter/README.md
@@ -18,12 +18,18 @@ subnet?"
 |-------|--------------|
 | **Passive listen** | brings `eth0` up with no address and captures LLDP/CDP/ARP: switch name, the port you are patched into, VLAN, switch mgmt IP |
 | **DHCP** | `NETMODE DHCP_CLIENT`, derives the lease, subnet CIDR, gateway, and DNS |
-| **Discovery** | `nmap -sn` host sweep of the access subnet |
-| **Service sample** | `nmap -sV --top-ports` over the live hosts for ports/services |
-| **Export** | merges passive + active data and writes the four output formats |
+| **Discovery + service sample** | `nmap -sn` sweep of the access subnet, then `nmap -sV --top-ports` over the live hosts |
+| **VLAN traversal** (opt-in) | passively sniffs 802.1Q tags, then for each tagged VLAN brings up `eth0.<vid>`, pulls DHCP, discovers + service-scans that subnet, and folds its hosts into the map labeled by VLAN/subnet |
+| **Export** | merges passive + active data across every segment and writes the four output formats |
 
 If DHCP fails the run is **not** aborted: it exports a passive-only map from the
 LLDP/CDP/ARP data and ends amber to flag the partial result.
+
+> **VLAN traversal is off by default** (`SCAN_TAGGED_VLANS=0`). Without it the map
+> only covers the access subnet (the one VLAN your port lands on). Turn it on to
+> map and scan the other VLANs a trunk carries, which is what makes the node count
+> match a payload like `full_recon`. It is active VLAN-hopping: authorized
+> engagements only, and a no-op on a plain access port.
 
 ## Output (loot)
 
@@ -37,11 +43,14 @@ topology.dot       <- Graphviz DOT (render: dot -Tpng topology.dot -o map.png)
 passive.pcap       <- full passive capture
 lldp.txt / cdp.txt <- neighbor decode
 passive_arp.tsv    <- passively observed hosts (IP + MAC)
-discovery.gnmap    services.{nmap,gnmap,xml}   <- raw nmap (XML imports elsewhere)
+native.discovery.gnmap  native.services.{nmap,xml}   <- access-subnet raw nmap
+vlan<id>.discovery.gnmap vlan<id>.services.{nmap,xml} <- per tagged-VLAN raw nmap
 ```
 
-The graph is shaped: `drop -> port -> switch -> vlan -> subnet -> gateway`, with
-each discovered host and DNS resolver hung off the subnet node. Free-text labels
+The graph is shaped `drop -> port -> switch`, then one **subnet node per segment**
+(the access subnet plus each scanned VLAN) hung off the switch, with that
+segment's gateway and hosts attached to it. Each subnet node and host carries its
+VLAN/subnet in the JSON, so a multi-VLAN map stays unambiguous. Free-text labels
 (switch descriptions, hostnames) are escaped per format, so a Cisco description
 full of quotes, commas, and parentheses still produces valid `.mmd`/`.dot`/JSON.
 
@@ -54,28 +63,38 @@ full of quotes, commas, and parentheses still produces valid `.mmd`/`.dot`/JSON.
 | `TOP_PORTS` | `100` | top-N TCP ports per host in the service sample |
 | `NMAP_TIMING` | `-T4` | `-T3` quieter, `-T5` aggressive |
 | `HOST_TIMEOUT` | `60s` | per-host budget so one slow host cannot stall the run |
+| `PASSIVE_VLAN_SECS` | `15` | passive 802.1Q listen window (needs `tcpdump`) |
+| `SCAN_TAGGED_VLANS` | `0` | **active VLAN-hopping**: scan each tagged VLAN and fold its hosts in. Set `1` for a full multi-VLAN map; leave `0` on an access port or when not authorized |
+| `VLAN_PROBE_IDS` | `""` | fallback VIDs to try if none are sniffed, e.g. `"10 20 30"` |
 | `LOOT_BASE` | `/root/loot/network_map` | where loot lands |
 
 ## Requirements
 
 - **`nmap`** (ships on the device) for discovery and the service sample.
 - **`tcpdump`** optional but recommended: it supplies the passive LLDP/CDP/ARP
-  layer (switch, port, VLAN). Without it the map still builds from DHCP + nmap,
-  minus the switch/port identity. `opkg update && opkg install tcpdump`.
+  layer (switch, port, VLAN) and the 802.1Q tag sniff used for VLAN traversal.
+  `opkg update && opkg install tcpdump`.
+- **`ip`** and **`udhcpc`** (on the device) are used by VLAN traversal to bring up
+  tagged sub-interfaces and lease each VLAN; `kmod-8021q` must be present for
+  tagged interfaces (`opkg install kmod-8021q`).
 
 ## LED / screen cues
 
 `SETUP` -> `SPECIAL` (passive listen) -> `STAGE1` DHCP -> `STAGE2` discovery ->
-`STAGE3` service sample -> `CLEANUP` (writing exports) -> `FINISH`. If DHCP
-failed it ends on amber `SPECIAL` (passive-only map). Red `FAIL` means `nmap` is
-missing. The final `ALERT` carries the host count.
+`STAGE4` VLAN map -> `STAGE5` per-VLAN scan (when `SCAN_TAGGED_VLANS=1`) ->
+`CLEANUP` (writing exports) -> `FINISH`. If DHCP failed it ends on amber `SPECIAL`
+(passive-only map). Red `FAIL` means `nmap` is missing. The final `ALERT` carries
+the host count and segment count.
 
 ## Limitations / scope
 
 - **It is a field-observed map from one vantage point**, not an authoritative
-  switch-fabric map. An access port shows you one VLAN and one subnet; to map the
-  whole estate, combine runs from multiple drops or with switch management data.
-- **Scope is L2-local**: it maps the segment the port lands on.
+  switch-fabric map. With `SCAN_TAGGED_VLANS=1` it covers the access subnet plus
+  the tagged VLANs the port trunks; VLANs the port does not carry, and segments
+  reachable only via L3 routing, are still out of view. Combine runs from multiple
+  drops or with switch management data for the whole estate.
+- **VLAN traversal needs a trunk**: on a plain access port no tags are seen, so it
+  maps just the one subnet (set `VLAN_PROBE_IDS` to force-try specific VIDs).
 - On a busy /24 the service sample is the slow part; run on USB-C power and tune
   `TOP_PORTS` / `NMAP_TIMING` for the time you have.
 - For a one-VLAN-only quick identity check use `port_id_beacon`; for a full

--- a/payloads/library/recon/net_map_exporter/README.md
+++ b/payloads/library/recon/net_map_exporter/README.md
@@ -10,7 +10,7 @@ subnet?"
 > runs nmap against the access subnet. Run only on networks you own or are
 > contracted to assess, within the agreed scope and time window. Nothing is
 > exfiltrated: all output stays on-device under `/root/loot/network_map/` until
-> you retrieve it. See the Legal and Disclaimer sections of the repository README.
+> you retrieve it.
 
 ## How it works
 

--- a/payloads/library/recon/net_map_exporter/README.md
+++ b/payloads/library/recon/net_map_exporter/README.md
@@ -1,0 +1,83 @@
+# Shark Jack Display - Network Map Exporter
+
+Builds a field-observed topology map from a single wired drop and exports it in
+formats you can drop straight into a deliverable: a Mermaid diagram, a Graphviz
+DOT graph, a generic JSON graph model, and a plain-text summary. One plug-in,
+one tidy map of "what is this drop actually connected to, and what lives on its
+subnet?"
+
+> **Authorized use only.** This payload is **active**: it pulls a DHCP lease and
+> runs nmap against the access subnet. Run only on networks you own or are
+> contracted to assess, within the agreed scope and time window. Nothing is
+> exfiltrated: all output stays on-device under `/root/loot/network_map/` until
+> you retrieve it. See the Legal and Disclaimer sections of the repository README.
+
+## How it works
+
+| Phase | What happens |
+|-------|--------------|
+| **Passive listen** | brings `eth0` up with no address and captures LLDP/CDP/ARP: switch name, the port you are patched into, VLAN, switch mgmt IP |
+| **DHCP** | `NETMODE DHCP_CLIENT`, derives the lease, subnet CIDR, gateway, and DNS |
+| **Discovery** | `nmap -sn` host sweep of the access subnet |
+| **Service sample** | `nmap -sV --top-ports` over the live hosts for ports/services |
+| **Export** | merges passive + active data and writes the four output formats |
+
+If DHCP fails the run is **not** aborted: it exports a passive-only map from the
+LLDP/CDP/ARP data and ends amber to flag the partial result.
+
+## Output (loot)
+
+`/root/loot/network_map/<UTC-timestamp>_<pid>/`:
+
+```
+summary.txt        <- observed topology + host count (read this first)
+topology.json      <- generic {nodes, edges} graph model (ingest into other tools)
+topology.mmd        <- Mermaid diagram (paste into a Markdown doc or mermaid.live)
+topology.dot       <- Graphviz DOT (render: dot -Tpng topology.dot -o map.png)
+passive.pcap       <- full passive capture
+lldp.txt / cdp.txt <- neighbor decode
+passive_arp.tsv    <- passively observed hosts (IP + MAC)
+discovery.gnmap    services.{nmap,gnmap,xml}   <- raw nmap (XML imports elsewhere)
+```
+
+The graph is shaped: `drop -> port -> switch -> vlan -> subnet -> gateway`, with
+each discovered host and DNS resolver hung off the subnet node. Free-text labels
+(switch descriptions, hostnames) are escaped per format, so a Cisco description
+full of quotes, commas, and parentheses still produces valid `.mmd`/`.dot`/JSON.
+
+## Configuration (top of [`payload.txt`](payload.txt))
+
+| Knob | Default | Notes |
+|------|---------|-------|
+| `DHCP_WAIT_SECS` | `30` | wait for a lease before falling back to passive-only |
+| `PASSIVE_LISTEN_SECS` | `75` | LLDP/CDP/ARP capture window (LLDP/CDP beacon every 30-60s) |
+| `TOP_PORTS` | `100` | top-N TCP ports per host in the service sample |
+| `NMAP_TIMING` | `-T4` | `-T3` quieter, `-T5` aggressive |
+| `HOST_TIMEOUT` | `60s` | per-host budget so one slow host cannot stall the run |
+| `LOOT_BASE` | `/root/loot/network_map` | where loot lands |
+
+## Requirements
+
+- **`nmap`** (ships on the device) for discovery and the service sample.
+- **`tcpdump`** optional but recommended: it supplies the passive LLDP/CDP/ARP
+  layer (switch, port, VLAN). Without it the map still builds from DHCP + nmap,
+  minus the switch/port identity. `opkg update && opkg install tcpdump`.
+
+## LED / screen cues
+
+`SETUP` -> `SPECIAL` (passive listen) -> `STAGE1` DHCP -> `STAGE2` discovery ->
+`STAGE3` service sample -> `CLEANUP` (writing exports) -> `FINISH`. If DHCP
+failed it ends on amber `SPECIAL` (passive-only map). Red `FAIL` means `nmap` is
+missing. The final `ALERT` carries the host count.
+
+## Limitations / scope
+
+- **It is a field-observed map from one vantage point**, not an authoritative
+  switch-fabric map. An access port shows you one VLAN and one subnet; to map the
+  whole estate, combine runs from multiple drops or with switch management data.
+- **Scope is L2-local**: it maps the segment the port lands on.
+- On a busy /24 the service sample is the slow part; run on USB-C power and tune
+  `TOP_PORTS` / `NMAP_TIMING` for the time you have.
+- For a one-VLAN-only quick identity check use `port_id_beacon`; for a full
+  drop validation use `jack_survey`. This payload is the one that produces
+  importable topology artifacts.

--- a/payloads/library/recon/net_map_exporter/payload.txt
+++ b/payloads/library/recon/net_map_exporter/payload.txt
@@ -5,6 +5,7 @@
 #  Target:      An authorized wired drop you want to diagram.
 #  Category:    recon / mapping / site-survey
 #  Version:     1.2
+#  Firmware:    Tested on Shark Jack Display 1.0.1
 # ----------------------------------------------------------------------------
 #  WHAT IT DOES
 #    Builds a field-observed topology map from one Shark Jack drop and exports

--- a/payloads/library/recon/net_map_exporter/payload.txt
+++ b/payloads/library/recon/net_map_exporter/payload.txt
@@ -46,7 +46,6 @@ LOOT_BASE="/root/loot/network_map"
 # ----------------------------------------------------------------------------
 
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-glow() { LED "$@" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
@@ -132,7 +131,7 @@ scan_segment() {                                 # scan_segment <iface> <target>
 }
 
 # ------------------------------ SETUP ---------------------------------------
-glow SETUP
+LED SETUP
 CLEAR_SCREEN 2>/dev/null
 say "Network Map Exporter"
 
@@ -144,7 +143,7 @@ MMD="$RUN/topology.mmd"
 DOT="$RUN/topology.dot"
 
 if ! have nmap; then
-  glow FAIL
+  LED FAIL
   say "nmap missing"
   echo "FAILED: nmap missing" > "$REPORT"
   ALERT "nmap missing" 8 2>/dev/null
@@ -152,7 +151,7 @@ if ! have nmap; then
 fi
 
 # --------------------------- PASSIVE LISTEN ---------------------------------
-glow SPECIAL
+LED SPECIAL
 say "Passive listen"
 ip link set eth0 up 2>/dev/null
 WAIT_FOR_LINK 2>/dev/null
@@ -203,7 +202,7 @@ SW_DESC="${L_DESC:-$C_PLAT}"
 [ -z "$VLAN" ] && VLAN="unknown"
 
 # ------------------------------ DHCP ----------------------------------------
-glow STAGE1
+LED STAGE1
 say "DHCP lease"
 NETMODE DHCP_CLIENT 2>/dev/null
 WAIT_FOR_LINK 2>/dev/null
@@ -244,7 +243,7 @@ DOMAIN=$(grep -hE '^(search|domain)' /tmp/resolv.conf.auto /etc/resolv.conf 2>/d
 # Always record the access/native segment so passive-only hosts have a home.
 printf '%s\t%s\t%s\t%s\n' "$VLAN" "$CIDR" "1" "$GATEWAY" >> "$RUN/segments.tsv"
 
-glow STAGE2
+LED STAGE2
 say "Host discovery"
 NATIVE_N=0
 if [ -n "$IP" ]; then
@@ -264,7 +263,7 @@ done < "$RUN/passive_arp.tsv"
 # ----------------------------- VLAN TRAVERSAL -------------------------------
 # Passively sniff 802.1Q tags (a trunk leaks them; an access port shows none),
 # then optionally scan each tagged VLAN and fold its hosts into the map.
-glow STAGE4
+LED STAGE4
 say "Mapping VLANs"
 PASSIVE_TAGS=""
 if have tcpdump; then
@@ -282,7 +281,7 @@ if [ "$SCAN_TAGGED_VLANS" = "1" ] && [ -n "$IP" ]; then
   if [ -n "$CANDIDATES" ] && have ip && have udhcpc; then
     lsmod 2>/dev/null | grep -q 8021q || modprobe 8021q 2>/dev/null
     for vid in $CANDIDATES; do
-      glow STAGE5
+      LED STAGE5
       say "VLAN $vid"
       spin_up "VLAN $vid: lease + scan"
       ip link add link eth0 name "eth0.$vid" type vlan id "$vid" 2>/dev/null
@@ -313,7 +312,7 @@ SEG_COUNT=$(wc -l < "$RUN/segments.tsv" 2>/dev/null | tr -d ' ')
 [ -z "$SEG_COUNT" ] && SEG_COUNT=0
 
 # ----------------------------- EMIT MERMAID ---------------------------------
-glow CLEANUP
+LED CLEANUP
 say "Writing map"
 
 DROP_ID="drop"
@@ -520,7 +519,7 @@ D_SWITCH=$(dot_txt "$SWITCH"); D_DESC=$(dot_txt "$SW_DESC"); D_PORT=$(dot_txt "$
   echo "=========================================================="
 } > "$REPORT"
 
-[ "$DHCP_OK" -eq 1 ] && glow FINISH || glow SPECIAL
+[ "$DHCP_OK" -eq 1 ] && LED FINISH || LED SPECIAL
 CLEAR_SCREEN 2>/dev/null
 say "Map export done"
 [ "$DHCP_OK" -eq 0 ] && say "Passive only (no DHCP)"

--- a/payloads/library/recon/net_map_exporter/payload.txt
+++ b/payloads/library/recon/net_map_exporter/payload.txt
@@ -35,7 +35,7 @@ NMAP_TIMING="-T4"
 HOST_TIMEOUT="60s"
 
 # VLAN traversal: discover + scan tagged VLANs and fold their hosts into the map.
-PASSIVE_VLAN_SECS=15           # passive 802.1Q listen window (needs tcpdump)
+PASSIVE_VLAN_SECS=15          # passive 802.1Q listen window (needs tcpdump)
 SCAN_TAGGED_VLANS=0           # 1 = bring up eth0.<vid>, DHCP, discover+scan each
                               #     tagged VLAN. ACTIVE VLAN-hopping; authorized
                               #     engagements only. No-op on a plain access port.

--- a/payloads/library/recon/net_map_exporter/payload.txt
+++ b/payloads/library/recon/net_map_exporter/payload.txt
@@ -47,7 +47,6 @@ LOOT_BASE="/root/loot/network_map"
 
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
-spin_down() { STOP_SPINNER 2>/dev/null; }
 
 safe_id() {
   echo "$1" | sed 's/[^A-Za-z0-9_]/_/g'
@@ -170,7 +169,7 @@ if have tcpdump; then
         if ($i=="is-at") { ip=$(i-1); gsub(/[,:]$/,"",ip); m=$(i+1); gsub(/[,:]$/,"",m); if (ip ~ /^[0-9]+\./ && m ~ /:/) print ip"\t"m }
       }
     }' | sort -u > "$RUN/passive_arp.tsv"
-  spin_down
+  STOP_SPINNER
 else
   : > "$RUN/lldp.txt"
   : > "$RUN/cdp.txt"
@@ -248,7 +247,7 @@ NATIVE_N=0
 if [ -n "$IP" ]; then
   CREATE_SPINNER "Discover $CIDR"
   NATIVE_N=$(scan_segment eth0 "$IP/$PREFIX" "$RUN/native" "$CIDR")
-  spin_down
+  STOP_SPINNER
 fi
 
 # Add passive ARP-only hosts (access segment) not already discovered actively.
@@ -269,7 +268,7 @@ if have tcpdump; then
   CREATE_SPINNER "802.1Q listen ${PASSIVE_VLAN_SECS}s"
   timeout "${PASSIVE_VLAN_SECS}s" tcpdump -e -nn -i eth0 -c 300 vlan 2>/dev/null \
     | grep -oE 'vlan [0-9]+' | awk '{print $2}' | sort -un > "$RUN/_tags.txt"
-  spin_down
+  STOP_SPINNER
   PASSIVE_TAGS=$(tr '\n' ' ' < "$RUN/_tags.txt" 2>/dev/null)
 fi
 TAGS_SEEN="$PASSIVE_TAGS"; [ -z "$TAGS_SEEN" ] && TAGS_SEEN="none (looks like an access port)"
@@ -300,7 +299,7 @@ if [ "$SCAN_TAGGED_VLANS" = "1" ] && [ -n "$IP" ]; then
         ip link set "eth0.$vid" down 2>/dev/null
         ip link del "eth0.$vid" 2>/dev/null
       fi
-      spin_down
+      STOP_SPINNER
     done
   fi
 fi

--- a/payloads/library/recon/net_map_exporter/payload.txt
+++ b/payloads/library/recon/net_map_exporter/payload.txt
@@ -1,0 +1,530 @@
+#!/bin/bash
+# ============================================================================
+#  Title:       Network Map Exporter (Shark Jack Display)
+#  Author:      Brent Mills
+#  Target:      An authorized wired drop you want to diagram.
+#  Category:    recon / mapping / site-survey
+#  Version:     1.2
+# ----------------------------------------------------------------------------
+#  WHAT IT DOES
+#    Builds a field-observed topology map from one Shark Jack drop and exports
+#    it in formats you can drop straight into a deliverable:
+#      - Passive LLDP/CDP/ARP .. switch, the port you are in, VLAN, mgmt IP.
+#      - DHCP .................. our lease, subnet CIDR, gateway, DNS.
+#      - Active discovery ...... nmap host sweep of the access subnet, then a
+#                                top-ports service sample of the live hosts.
+#      - VLAN traversal ........ (opt-in) passively sniff 802.1Q tags, then for
+#                                each tagged VLAN bring up eth0.<vid>, pull DHCP,
+#                                discover + scan that subnet, and fold its hosts
+#                                into the map labeled by VLAN/subnet.
+#      - Exports ............... topology.json (generic graph), topology.mmd
+#                                (Mermaid), topology.dot (Graphviz), summary.txt.
+#
+#  AUTHORIZATION
+#    This payload is ACTIVE: it pulls a DHCP lease and runs nmap. With
+#    SCAN_TAGGED_VLANS=1 it also tags onto other VLANs (active VLAN-hopping).
+#    Run ONLY on networks you own or are contracted to assess, within the agreed
+#    scope and time window. Output stays on-device in /root/loot until you pull it.
+# ============================================================================
+
+# ------------------------------- CONFIG -------------------------------------
+DHCP_WAIT_SECS=30
+PASSIVE_LISTEN_SECS=75
+TOP_PORTS=100
+NMAP_TIMING="-T4"
+HOST_TIMEOUT="60s"
+
+# VLAN traversal: discover + scan tagged VLANs and fold their hosts into the map.
+PASSIVE_VLAN_SECS=15           # passive 802.1Q listen window (needs tcpdump)
+SCAN_TAGGED_VLANS=0           # 1 = bring up eth0.<vid>, DHCP, discover+scan each
+                              #     tagged VLAN. ACTIVE VLAN-hopping; authorized
+                              #     engagements only. No-op on a plain access port.
+VLAN_PROBE_IDS=""             # fallback VIDs if none are sniffed, e.g. "10 20 30"
+
+LOOT_BASE="/root/loot/network_map"
+# ----------------------------------------------------------------------------
+
+say()  { SCREEN_WRITE "$*" 2>/dev/null; }
+glow() { LED "$@" 2>/dev/null; }
+have() { command -v "$1" >/dev/null 2>&1; }
+spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
+spin_down() { STOP_SPINNER 2>/dev/null; }
+
+safe_id() {
+  echo "$1" | sed 's/[^A-Za-z0-9_]/_/g'
+}
+
+json_escape() {
+  echo "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+# Sanitize free text for graph LABELS (node IDs use safe_id; these are the
+# visible strings). Switch descriptions/hostnames carry quotes, commas, and
+# parens that break the diagram formats, so scrub per-format before embedding.
+# Newlines are stripped; the per-format line breaks (<br/> or \n) are added by
+# the emitter, not by these values.
+mmd_txt() { printf '%s' "$1" | tr -d '\r\n' | tr '"' "'"; }            # Mermaid quoted label
+dot_txt() { printf '%s' "$1" | tr -d '\r\n' | sed 's/\\/\\\\/g; s/"/\\"/g'; }  # Graphviz label
+
+ip_to_int() { local IFS=.; set -- $1; echo $(( ($1<<24)|($2<<16)|($3<<8)|$4 )); }
+int_to_ip() { local i=$1; echo "$(((i>>24)&255)).$(((i>>16)&255)).$(((i>>8)&255)).$((i&255))"; }
+mask_for()  { local p=$1; echo $(( (0xFFFFFFFF << (32-p)) & 0xFFFFFFFF )); }
+network_cidr() {
+  local ip=$1 p=$2 m
+  [ -z "$ip" ] || [ -z "$p" ] && return
+  m=$(mask_for "$p")
+  echo "$(int_to_ip $(( $(ip_to_int "$ip") & m )))/$p"
+}
+
+lldp_field() {
+  awk -v lbl="$2" '
+    index($0,lbl) {
+      rest=substr($0,index($0,lbl)); val=""
+      if (match(rest,/: /)) val=substr(rest,RSTART+2)
+      if (val ~ /^[ \t]*$/) getline val
+      gsub(/^[ \t]+|[ \t]+$/,"",val)
+      sub(/^Subtype[^:]*: /,"",val)
+      print val
+      exit
+    }' "$1" 2>/dev/null
+}
+
+# Parse one nmap -sV normal-output file and APPEND host rows to hosts.tsv, each
+# tagged with the segment (subnet CIDR) it belongs to. Columns:
+#   ip \t hostname \t mac \t vendor \t ports \t segment_cidr
+parse_seg() {                                    # parse_seg <services.nmap> <seg_cidr>
+  awk -v seg="$2" '
+    function flush() {
+      if (ip=="") return
+      printf "%s\t%s\t%s\t%s\t%s\t%s\n", ip, host, mac, vendor, ports, seg
+    }
+    /^Nmap scan report for / {
+      flush()
+      line=$0; sub(/^Nmap scan report for /,"",line)
+      if (line ~ /\(.*\)/) { host=line; sub(/ \(.*/,"",host); ip=line; sub(/.*\(/,"",ip); sub(/\)/,"",ip) }
+      else { host="-"; ip=line }
+      mac="-"; vendor="-"; ports=""
+    }
+    /^[0-9]+\/tcp[ \t]+open/ { split($1,a,"/"); ports=ports (ports==""?"":",") a[1] "/" $3 }
+    /^MAC Address: / {
+      mac=$3; vendor=$0
+      sub(/^MAC Address: [^ ]+ ?/,"",vendor); gsub(/^\(|\)$/,"",vendor)
+      if (vendor=="") vendor="-"
+    }
+    END { flush() }
+  ' "$1" 2>/dev/null >> "$RUN/hosts.tsv"
+}
+
+# Discover + service-scan a subnet through a given interface, folding the parsed
+# hosts (labeled with seg) into hosts.tsv. Echoes the live-host count.
+scan_segment() {                                 # scan_segment <iface> <target> <base> <seg_cidr>
+  local iface=$1 target=$2 base=$3 seg=$4 n=0
+  nmap -sn $NMAP_TIMING -e "$iface" -oG "$base.discovery.gnmap" "$target" >/dev/null 2>&1
+  awk '/Status: Up/{print $2}' "$base.discovery.gnmap" 2>/dev/null | sort -u > "$base.up.txt"
+  n=$(wc -l < "$base.up.txt" 2>/dev/null | tr -d ' '); [ -z "$n" ] && n=0
+  if [ "$n" -gt 0 ]; then
+    nmap -sV $NMAP_TIMING --top-ports "$TOP_PORTS" --host-timeout "$HOST_TIMEOUT" \
+      -e "$iface" -iL "$base.up.txt" -oN "$base.services.nmap" -oX "$base.services.xml" >/dev/null 2>&1
+    parse_seg "$base.services.nmap" "$seg"
+  fi
+  echo "$n"
+}
+
+# ------------------------------ SETUP ---------------------------------------
+glow SETUP
+CLEAR_SCREEN 2>/dev/null
+say "Network Map Exporter"
+
+RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
+mkdir -p "$RUN"
+REPORT="$RUN/summary.txt"
+JSON="$RUN/topology.json"
+MMD="$RUN/topology.mmd"
+DOT="$RUN/topology.dot"
+
+if ! have nmap; then
+  glow FAIL
+  say "nmap missing"
+  echo "FAILED: nmap missing" > "$REPORT"
+  ALERT "nmap missing" 8 2>/dev/null
+  exit 1
+fi
+
+# --------------------------- PASSIVE LISTEN ---------------------------------
+glow SPECIAL
+say "Passive listen"
+ip link set eth0 up 2>/dev/null
+WAIT_FOR_LINK 2>/dev/null
+
+PCAP="$RUN/passive.pcap"
+if have tcpdump; then
+  spin_up "LLDP/CDP/ARP"
+  timeout "${PASSIVE_LISTEN_SECS}s" tcpdump -i eth0 -s 0 -w "$PCAP" 2>/dev/null
+  tcpdump -nn -v -r "$PCAP" 'ether proto 0x88cc' 2>/dev/null > "$RUN/lldp.txt"
+  tcpdump -nn -v -r "$PCAP" 'ether host 01:00:0c:cc:cc:cc' 2>/dev/null > "$RUN/cdp.txt"
+  tcpdump -nn -e -r "$PCAP" arp 2>/dev/null | awk '
+    {
+      mac=""
+      for (i=1;i<=NF;i++) if (mac=="" && $i ~ /^([0-9a-f]{2}:){5}[0-9a-f]{2}$/) mac=$i
+      for (i=1;i<=NF;i++) {
+        if ($i=="tell")  { ip=$(i+1); gsub(/[,:]$/,"",ip); if (ip ~ /^[0-9]+\./ && mac!="") print ip"\t"mac }
+        if ($i=="is-at") { ip=$(i-1); gsub(/[,:]$/,"",ip); m=$(i+1); gsub(/[,:]$/,"",m); if (ip ~ /^[0-9]+\./ && m ~ /:/) print ip"\t"m }
+      }
+    }' | sort -u > "$RUN/passive_arp.tsv"
+  spin_down
+else
+  : > "$RUN/lldp.txt"
+  : > "$RUN/cdp.txt"
+  : > "$RUN/passive_arp.tsv"
+  echo "tcpdump missing; passive capture skipped." > "$RUN/passive_skipped.txt"
+fi
+
+L_NAME=$(lldp_field "$RUN/lldp.txt" 'System Name TLV')
+L_PORT=$(lldp_field "$RUN/lldp.txt" 'Port ID TLV')
+L_DESC=$(lldp_field "$RUN/lldp.txt" 'System Description TLV')
+L_MGMT=$(grep -i 'Management Address' "$RUN/lldp.txt" 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+L_VLAN=$(grep -iE 'PVID|Port VLAN ID' "$RUN/lldp.txt" 2>/dev/null | grep -oE '[0-9]+' | tail -1)
+
+C_DEV=$(grep -i 'Device-ID' "$RUN/cdp.txt" 2>/dev/null | head -1 | sed "s/.*: '//; s/'.*//")
+C_PLAT=$(grep -i 'Platform' "$RUN/cdp.txt" 2>/dev/null | head -1 | sed "s/.*: '//; s/'.*//")
+C_PORT=$(grep -i 'Port-ID' "$RUN/cdp.txt" 2>/dev/null | head -1 | sed "s/.*: '//; s/'.*//")
+C_NVLAN=$(grep -i 'Native VLAN' "$RUN/cdp.txt" 2>/dev/null | head -1 | grep -oE '[0-9]+' | head -1)
+C_ADDR=$(grep -iA2 'Address' "$RUN/cdp.txt" 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+
+SWITCH="${L_NAME:-$C_DEV}"
+PORT="${L_PORT:-$C_PORT}"
+VLAN="${L_VLAN:-$C_NVLAN}"
+SW_MGMT="${L_MGMT:-$C_ADDR}"
+SW_DESC="${L_DESC:-$C_PLAT}"
+
+[ -z "$SWITCH" ] && SWITCH="Unknown switch"
+[ -z "$PORT" ] && PORT="Unknown port"
+[ -z "$VLAN" ] && VLAN="unknown"
+
+# ------------------------------ DHCP ----------------------------------------
+glow STAGE1
+say "DHCP lease"
+NETMODE DHCP_CLIENT 2>/dev/null
+WAIT_FOR_LINK 2>/dev/null
+
+IP=""; PREFIX=""
+for _ in $(seq 1 "$DHCP_WAIT_SECS"); do
+  line=$(ip -o -4 addr show eth0 2>/dev/null | awk '{print $4}' | head -1)
+  if [ -n "$line" ]; then
+    IP=${line%/*}
+    PREFIX=${line#*/}
+    break
+  fi
+  sleep 1
+done
+
+# No lease is not fatal: the passive LLDP/CDP/ARP map is still worth exporting,
+# so note it and continue (active host discovery is simply skipped below).
+DHCP_OK=1
+if [ -z "$IP" ]; then
+  DHCP_OK=0
+  say "No DHCP (passive only)"
+fi
+
+GATEWAY=$(ip route 2>/dev/null | awk '/default/{print $3; exit}')
+CIDR=$(network_cidr "$IP" "$PREFIX")
+DNS=$(grep -h nameserver /tmp/resolv.conf.auto /etc/resolv.conf 2>/dev/null | awk '{print $2}' | sort -u)
+DOMAIN=$(grep -hE '^(search|domain)' /tmp/resolv.conf.auto /etc/resolv.conf 2>/dev/null | awk '{print $2}' | head -1)
+
+[ -z "$CIDR" ] && CIDR="unknown"
+[ -z "$GATEWAY" ] && GATEWAY="unknown"
+
+# -------------------------- DISCOVERY / SERVICES -----------------------------
+# hosts.tsv : ip \t host \t mac \t vendor \t ports \t segment_cidr  (accumulator)
+# segments.tsv : vlan_label \t cidr \t is_access \t gateway
+: > "$RUN/hosts.tsv"
+: > "$RUN/segments.tsv"
+
+# Always record the access/native segment so passive-only hosts have a home.
+printf '%s\t%s\t%s\t%s\n' "$VLAN" "$CIDR" "1" "$GATEWAY" >> "$RUN/segments.tsv"
+
+glow STAGE2
+say "Host discovery"
+NATIVE_N=0
+if [ -n "$IP" ]; then
+  spin_up "Discover $CIDR"
+  NATIVE_N=$(scan_segment eth0 "$IP/$PREFIX" "$RUN/native" "$CIDR")
+  spin_down
+fi
+
+# Add passive ARP-only hosts (access segment) not already discovered actively.
+awk -F'\t' '{print $1}' "$RUN/hosts.tsv" 2>/dev/null > "$RUN/known_ips.txt"
+while IFS=$'\t' read -r aip amac; do
+  [ -z "$aip" ] && continue
+  grep -qx "$aip" "$RUN/known_ips.txt" 2>/dev/null && continue
+  printf "%s\t%s\t%s\t%s\t%s\t%s\n" "$aip" "-" "$amac" "passive-observed" "-" "$CIDR" >> "$RUN/hosts.tsv"
+done < "$RUN/passive_arp.tsv"
+
+# ----------------------------- VLAN TRAVERSAL -------------------------------
+# Passively sniff 802.1Q tags (a trunk leaks them; an access port shows none),
+# then optionally scan each tagged VLAN and fold its hosts into the map.
+glow STAGE4
+say "Mapping VLANs"
+PASSIVE_TAGS=""
+if have tcpdump; then
+  spin_up "802.1Q listen ${PASSIVE_VLAN_SECS}s"
+  timeout "${PASSIVE_VLAN_SECS}s" tcpdump -e -nn -i eth0 -c 300 vlan 2>/dev/null \
+    | grep -oE 'vlan [0-9]+' | awk '{print $2}' | sort -un > "$RUN/_tags.txt"
+  spin_down
+  PASSIVE_TAGS=$(tr '\n' ' ' < "$RUN/_tags.txt" 2>/dev/null)
+fi
+TAGS_SEEN="$PASSIVE_TAGS"; [ -z "$TAGS_SEEN" ] && TAGS_SEEN="none (looks like an access port)"
+
+if [ "$SCAN_TAGGED_VLANS" = "1" ] && [ -n "$IP" ]; then
+  CANDIDATES="$PASSIVE_TAGS"
+  [ -z "$CANDIDATES" ] && CANDIDATES="$VLAN_PROBE_IDS"
+  if [ -n "$CANDIDATES" ] && have ip && have udhcpc; then
+    lsmod 2>/dev/null | grep -q 8021q || modprobe 8021q 2>/dev/null
+    for vid in $CANDIDATES; do
+      glow STAGE5
+      say "VLAN $vid"
+      spin_up "VLAN $vid: lease + scan"
+      ip link add link eth0 name "eth0.$vid" type vlan id "$vid" 2>/dev/null
+      if ip link show "eth0.$vid" >/dev/null 2>&1; then
+        ip link set "eth0.$vid" up 2>/dev/null
+        udhcpc -i "eth0.$vid" -n -q -t 4 -T 3 >/dev/null 2>&1
+        vline=$(ip -o -4 addr show "eth0.$vid" 2>/dev/null | awk '{print $4}' | head -1)
+        if [ -n "$vline" ]; then
+          vcidr=$(network_cidr "${vline%/*}" "${vline#*/}")
+          vgw=$(ip route 2>/dev/null | awk -v d="eth0.$vid" '/default/ && $0 ~ ("dev "d){print $3; exit}')
+          [ -z "$vgw" ] && vgw="unknown"
+          if [ "$vcidr" != "$CIDR" ]; then
+            scan_segment "eth0.$vid" "$vcidr" "$RUN/vlan$vid" "$vcidr" >/dev/null
+            printf '%s\t%s\t%s\t%s\n' "vlan$vid" "$vcidr" "0" "$vgw" >> "$RUN/segments.tsv"
+          fi
+        fi
+        ip link set "eth0.$vid" down 2>/dev/null
+        ip link del "eth0.$vid" 2>/dev/null
+      fi
+      spin_down
+    done
+  fi
+fi
+
+TOTAL_HOSTS=$(wc -l < "$RUN/hosts.tsv" 2>/dev/null | tr -d ' ')
+[ -z "$TOTAL_HOSTS" ] && TOTAL_HOSTS=0
+SEG_COUNT=$(wc -l < "$RUN/segments.tsv" 2>/dev/null | tr -d ' ')
+[ -z "$SEG_COUNT" ] && SEG_COUNT=0
+
+# ----------------------------- EMIT MERMAID ---------------------------------
+glow CLEANUP
+say "Writing map"
+
+DROP_ID="drop"
+SWITCH_ID="switch_$(safe_id "$SWITCH")"
+PORT_ID="port_$(safe_id "$PORT")"
+ASID="subnet_$(safe_id "$CIDR")"          # access/native subnet node (DNS hangs here)
+
+# Pre-sanitize the fixed-node labels once per format.
+M_SWITCH=$(mmd_txt "$SWITCH"); M_DESC=$(mmd_txt "$SW_DESC"); M_PORT=$(mmd_txt "$PORT")
+D_SWITCH=$(dot_txt "$SWITCH"); D_DESC=$(dot_txt "$SW_DESC"); D_PORT=$(dot_txt "$PORT")
+
+{
+  echo "graph TD"
+  echo "  $DROP_ID[\"Shark Jack Drop<br/>$IP/$PREFIX\"]"
+  echo "  $SWITCH_ID[\"Switch<br/>$M_SWITCH<br/>$M_DESC\"]"
+  echo "  $PORT_ID[\"Port<br/>$M_PORT\"]"
+  echo "  $DROP_ID --> $PORT_ID"
+  echo "  $PORT_ID --> $SWITCH_ID"
+
+  # One subnet node per segment (access + each scanned VLAN), off the switch.
+  while IFS=$'\t' read -r seg_vlan seg_cidr seg_access seg_gw; do
+    [ -z "$seg_cidr" ] && continue
+    sid="subnet_$(safe_id "$seg_cidr")"
+    echo "  $sid[\"Subnet<br/>$(mmd_txt "$seg_cidr")<br/>VLAN $(mmd_txt "$seg_vlan")\"]"
+    echo "  $SWITCH_ID --> $sid"
+    if [ -n "$seg_gw" ] && [ "$seg_gw" != "unknown" ] && [ "$seg_gw" != "-" ]; then
+      gid="gateway_$(safe_id "$seg_gw")"
+      echo "  $gid[\"Gateway<br/>$(mmd_txt "$seg_gw")\"]"
+      echo "  $sid --> $gid"
+    fi
+  done < "$RUN/segments.tsv"
+
+  # Hosts hang off the subnet node of the segment they were found on.
+  while IFS=$'\t' read -r hip hhost hmac hvendor hports hseg; do
+    [ -z "$hip" ] && continue
+    hid="host_$(safe_id "$hip")"; sid="subnet_$(safe_id "$hseg")"
+    mh=$(mmd_txt "$hhost"); mp=$(mmd_txt "$hports")
+    label="$hip"
+    [ "$hhost" != "-" ] && label="$mh<br/>$hip"
+    [ "$hports" != "-" ] && [ -n "$hports" ] && label="$label<br/>$mp"
+    echo "  $hid[\"$label\"]"
+    echo "  $sid --> $hid"
+  done < "$RUN/hosts.tsv"
+
+  for d in $DNS; do
+    did="dns_$(safe_id "$d")"
+    echo "  $did[\"DNS<br/>$d\"]"
+    echo "  $ASID --> $did"
+  done
+} > "$MMD"
+
+# ------------------------------- EMIT DOT -----------------------------------
+{
+  echo "digraph topology {"
+  echo "  graph [rankdir=LR];"
+  echo "  node [shape=box];"
+  echo "  \"$DROP_ID\" [label=\"Shark Jack Drop\\n$IP/$PREFIX\"];"
+  echo "  \"$SWITCH_ID\" [label=\"Switch\\n$D_SWITCH\\n$D_DESC\"];"
+  echo "  \"$PORT_ID\" [label=\"Port\\n$D_PORT\"];"
+  echo "  \"$DROP_ID\" -> \"$PORT_ID\";"
+  echo "  \"$PORT_ID\" -> \"$SWITCH_ID\";"
+
+  while IFS=$'\t' read -r seg_vlan seg_cidr seg_access seg_gw; do
+    [ -z "$seg_cidr" ] && continue
+    sid="subnet_$(safe_id "$seg_cidr")"
+    echo "  \"$sid\" [label=\"Subnet\\n$(dot_txt "$seg_cidr")\\nVLAN $(dot_txt "$seg_vlan")\"];"
+    echo "  \"$SWITCH_ID\" -> \"$sid\";"
+    if [ -n "$seg_gw" ] && [ "$seg_gw" != "unknown" ] && [ "$seg_gw" != "-" ]; then
+      gid="gateway_$(safe_id "$seg_gw")"
+      echo "  \"$gid\" [label=\"Gateway\\n$(dot_txt "$seg_gw")\"];"
+      echo "  \"$sid\" -> \"$gid\";"
+    fi
+  done < "$RUN/segments.tsv"
+
+  while IFS=$'\t' read -r hip hhost hmac hvendor hports hseg; do
+    [ -z "$hip" ] && continue
+    hid="host_$(safe_id "$hip")"; sid="subnet_$(safe_id "$hseg")"
+    dh=$(dot_txt "$hhost"); dp=$(dot_txt "$hports")
+    label="$hip"
+    [ "$hhost" != "-" ] && label="$dh\\n$hip"
+    [ "$hports" != "-" ] && [ -n "$hports" ] && label="$label\\n$dp"
+    echo "  \"$hid\" [label=\"$label\"];"
+    echo "  \"$sid\" -> \"$hid\";"
+  done < "$RUN/hosts.tsv"
+
+  for d in $DNS; do
+    did="dns_$(safe_id "$d")"
+    echo "  \"$did\" [label=\"DNS\\n$d\"];"
+    echo "  \"$ASID\" -> \"$did\";"
+  done
+
+  echo "}"
+} > "$DOT"
+
+# ------------------------------ EMIT JSON -----------------------------------
+{
+  echo "{"
+  echo "  \"generated_at\": \"$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)\","
+  echo "  \"scope\": \"field_observed_single_vantage\","
+  echo "  \"nodes\": ["
+  echo "    {\"id\":\"$DROP_ID\",\"type\":\"drop\",\"label\":\"Shark Jack Drop\",\"ip\":\"$(json_escape "$IP")\",\"prefix\":\"$(json_escape "$PREFIX")\"},"
+  echo "    {\"id\":\"$SWITCH_ID\",\"type\":\"switch\",\"label\":\"$(json_escape "$SWITCH")\",\"management_ip\":\"$(json_escape "$SW_MGMT")\",\"description\":\"$(json_escape "$SW_DESC")\"},"
+  echo "    {\"id\":\"$PORT_ID\",\"type\":\"switch_port\",\"label\":\"$(json_escape "$PORT")\"}"
+
+  while IFS=$'\t' read -r seg_vlan seg_cidr seg_access seg_gw; do
+    [ -z "$seg_cidr" ] && continue
+    sid="subnet_$(safe_id "$seg_cidr")"
+    echo "    ,{\"id\":\"$sid\",\"type\":\"subnet\",\"label\":\"$(json_escape "$seg_cidr")\",\"vlan\":\"$(json_escape "$seg_vlan")\",\"access\":$([ "$seg_access" = "1" ] && echo true || echo false)}"
+    if [ -n "$seg_gw" ] && [ "$seg_gw" != "unknown" ] && [ "$seg_gw" != "-" ]; then
+      gid="gateway_$(safe_id "$seg_gw")"
+      echo "    ,{\"id\":\"$gid\",\"type\":\"gateway\",\"label\":\"$(json_escape "$seg_gw")\"}"
+    fi
+  done < "$RUN/segments.tsv"
+
+  while IFS=$'\t' read -r hip hhost hmac hvendor hports hseg; do
+    [ -z "$hip" ] && continue
+    hid="host_$(safe_id "$hip")"
+    echo "    ,{\"id\":\"$hid\",\"type\":\"host\",\"ip\":\"$(json_escape "$hip")\",\"hostname\":\"$(json_escape "$hhost")\",\"mac\":\"$(json_escape "$hmac")\",\"vendor\":\"$(json_escape "$hvendor")\",\"ports\":\"$(json_escape "$hports")\",\"subnet\":\"$(json_escape "$hseg")\"}"
+  done < "$RUN/hosts.tsv"
+
+  for d in $DNS; do
+    did="dns_$(safe_id "$d")"
+    echo "    ,{\"id\":\"$did\",\"type\":\"dns\",\"ip\":\"$(json_escape "$d")\"}"
+  done
+
+  echo "  ],"
+  echo "  \"edges\": ["
+  echo "    {\"from\":\"$DROP_ID\",\"to\":\"$PORT_ID\",\"relationship\":\"connected_to\"},"
+  echo "    {\"from\":\"$PORT_ID\",\"to\":\"$SWITCH_ID\",\"relationship\":\"belongs_to\"}"
+
+  while IFS=$'\t' read -r seg_vlan seg_cidr seg_access seg_gw; do
+    [ -z "$seg_cidr" ] && continue
+    sid="subnet_$(safe_id "$seg_cidr")"
+    echo "    ,{\"from\":\"$SWITCH_ID\",\"to\":\"$sid\",\"relationship\":\"carries_subnet\"}"
+    if [ -n "$seg_gw" ] && [ "$seg_gw" != "unknown" ] && [ "$seg_gw" != "-" ]; then
+      gid="gateway_$(safe_id "$seg_gw")"
+      echo "    ,{\"from\":\"$sid\",\"to\":\"$gid\",\"relationship\":\"default_gateway\"}"
+    fi
+  done < "$RUN/segments.tsv"
+
+  while IFS=$'\t' read -r hip hhost hmac hvendor hports hseg; do
+    [ -z "$hip" ] && continue
+    hid="host_$(safe_id "$hip")"; sid="subnet_$(safe_id "$hseg")"
+    echo "    ,{\"from\":\"$sid\",\"to\":\"$hid\",\"relationship\":\"observed_host\"}"
+  done < "$RUN/hosts.tsv"
+
+  for d in $DNS; do
+    did="dns_$(safe_id "$d")"
+    echo "    ,{\"from\":\"$ASID\",\"to\":\"$did\",\"relationship\":\"resolver\"}"
+  done
+
+  echo "  ]"
+  echo "}"
+} > "$JSON"
+
+# ------------------------------- SUMMARY ------------------------------------
+{
+  echo "=========================================================="
+  echo " SHARK JACK DISPLAY - NETWORK MAP EXPORTER"
+  echo "=========================================================="
+  echo " Run time : $(date -u '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null)"
+  echo " Loot     : $RUN"
+  echo ""
+  echo "---- OBSERVED TOPOLOGY -----------------------------------"
+  echo " Drop     : Shark Jack on eth0"
+  echo " Network  : $([ "$DHCP_OK" -eq 1 ] && echo "DHCP lease OK" || echo "no DHCP - passive map only")"
+  echo " Switch   : $SWITCH"
+  echo " Port     : $PORT"
+  echo " Mgmt IP  : ${SW_MGMT:--}"
+  echo " Access VLAN: $VLAN"
+  echo " Gateway  : $GATEWAY"
+  echo " DNS      : ${DNS:--}"
+  echo " Hosts    : $TOTAL_HOSTS across $SEG_COUNT segment(s)"
+  echo ""
+  echo "---- SEGMENTS (subnets / VLANs mapped) -------------------"
+  echo " Tagged VLANs seen passively: $TAGS_SEEN"
+  if [ "$SCAN_TAGGED_VLANS" != "1" ]; then
+    echo " (VLAN traversal off: set SCAN_TAGGED_VLANS=1 to scan tagged VLANs)"
+  fi
+  while IFS=$'\t' read -r seg_vlan seg_cidr seg_access seg_gw; do
+    [ -z "$seg_cidr" ] && continue
+    sn=$(awk -F'\t' -v s="$seg_cidr" '$6==s' "$RUN/hosts.tsv" 2>/dev/null | wc -l | tr -d ' ')
+    lbl="VLAN $seg_vlan"; [ "$seg_access" = "1" ] && lbl="$lbl (access)"
+    printf " %-22s %-20s gw %-15s %s hosts\n" "$seg_cidr" "$lbl" "${seg_gw:--}" "$sn"
+  done < "$RUN/segments.tsv"
+  echo ""
+  echo "---- EXPORTS ---------------------------------------------"
+  echo " topology.json  - generic graph model (nodes carry vlan/subnet)"
+  echo " topology.mmd   - Mermaid diagram"
+  echo " topology.dot   - Graphviz DOT"
+  echo ""
+  echo "---- RAW ARTIFACTS ---------------------------------------"
+  echo " passive.pcap"
+  echo " lldp.txt / cdp.txt"
+  echo " passive_arp.tsv"
+  echo " native.discovery.gnmap / native.services.{nmap,xml}"
+  echo " vlan<id>.discovery.gnmap / vlan<id>.services.{nmap,xml}  (per scanned VLAN)"
+  echo ""
+  echo "---- LIMITATION ------------------------------------------"
+  echo " This is a field-observed map from one network drop. Tagged VLANs are"
+  echo " mapped only when SCAN_TAGGED_VLANS=1 and the port trunks them. It is"
+  echo " not an authoritative switch fabric map unless combined with additional"
+  echo " vantage points or switch management data."
+  echo "=========================================================="
+} > "$REPORT"
+
+[ "$DHCP_OK" -eq 1 ] && glow FINISH || glow SPECIAL
+CLEAR_SCREEN 2>/dev/null
+say "Map export done"
+[ "$DHCP_OK" -eq 0 ] && say "Passive only (no DHCP)"
+say "Switch: $SWITCH"
+say "Subnet: $CIDR"
+say "Hosts: $TOTAL_HOSTS"
+ALERT "Network map: $TOTAL_HOSTS hosts$([ "$DHCP_OK" -eq 0 ] && echo ' (passive only)')" 12 2>/dev/null
+exit 0

--- a/payloads/library/recon/net_map_exporter/payload.txt
+++ b/payloads/library/recon/net_map_exporter/payload.txt
@@ -47,7 +47,6 @@ LOOT_BASE="/root/loot/network_map"
 
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
-spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 
 safe_id() {
@@ -158,7 +157,7 @@ WAIT_FOR_LINK 2>/dev/null
 
 PCAP="$RUN/passive.pcap"
 if have tcpdump; then
-  spin_up "LLDP/CDP/ARP"
+  CREATE_SPINNER "LLDP/CDP/ARP"
   timeout "${PASSIVE_LISTEN_SECS}s" tcpdump -i eth0 -s 0 -w "$PCAP" 2>/dev/null
   tcpdump -nn -v -r "$PCAP" 'ether proto 0x88cc' 2>/dev/null > "$RUN/lldp.txt"
   tcpdump -nn -v -r "$PCAP" 'ether host 01:00:0c:cc:cc:cc' 2>/dev/null > "$RUN/cdp.txt"
@@ -247,7 +246,7 @@ LED STAGE2
 say "Host discovery"
 NATIVE_N=0
 if [ -n "$IP" ]; then
-  spin_up "Discover $CIDR"
+  CREATE_SPINNER "Discover $CIDR"
   NATIVE_N=$(scan_segment eth0 "$IP/$PREFIX" "$RUN/native" "$CIDR")
   spin_down
 fi
@@ -267,7 +266,7 @@ LED STAGE4
 say "Mapping VLANs"
 PASSIVE_TAGS=""
 if have tcpdump; then
-  spin_up "802.1Q listen ${PASSIVE_VLAN_SECS}s"
+  CREATE_SPINNER "802.1Q listen ${PASSIVE_VLAN_SECS}s"
   timeout "${PASSIVE_VLAN_SECS}s" tcpdump -e -nn -i eth0 -c 300 vlan 2>/dev/null \
     | grep -oE 'vlan [0-9]+' | awk '{print $2}' | sort -un > "$RUN/_tags.txt"
   spin_down
@@ -283,7 +282,7 @@ if [ "$SCAN_TAGGED_VLANS" = "1" ] && [ -n "$IP" ]; then
     for vid in $CANDIDATES; do
       LED STAGE5
       say "VLAN $vid"
-      spin_up "VLAN $vid: lease + scan"
+      CREATE_SPINNER "VLAN $vid: lease + scan"
       ip link add link eth0 name "eth0.$vid" type vlan id "$vid" 2>/dev/null
       if ip link show "eth0.$vid" >/dev/null 2>&1; then
         ip link set "eth0.$vid" up 2>/dev/null

--- a/payloads/library/recon/net_map_exporter/payload.txt
+++ b/payloads/library/recon/net_map_exporter/payload.txt
@@ -524,7 +524,7 @@ CLEAR_SCREEN 2>/dev/null
 say "Map export done"
 [ "$DHCP_OK" -eq 0 ] && say "Passive only (no DHCP)"
 say "Switch: $SWITCH"
-say "Subnet: $CIDR"
 say "Hosts: $TOTAL_HOSTS"
-ALERT "Network map: $TOTAL_HOSTS hosts$([ "$DHCP_OK" -eq 0 ] && echo ' (passive only)')" 12 2>/dev/null
+say "Segments: $SEG_COUNT"
+ALERT "Network map: $TOTAL_HOSTS hosts across $SEG_COUNT segment(s)$([ "$DHCP_OK" -eq 0 ] && echo ' (passive only)')" 12 2>/dev/null
 exit 0

--- a/payloads/library/recon/net_map_exporter/payload.txt
+++ b/payloads/library/recon/net_map_exporter/payload.txt
@@ -45,7 +45,6 @@ VLAN_PROBE_IDS=""             # fallback VIDs if none are sniffed, e.g. "10 20 3
 LOOT_BASE="/root/loot/network_map"
 # ----------------------------------------------------------------------------
 
-say()  { SCREEN_WRITE "$*" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
 safe_id() {
@@ -131,7 +130,7 @@ scan_segment() {                                 # scan_segment <iface> <target>
 # ------------------------------ SETUP ---------------------------------------
 LED SETUP
 CLEAR_SCREEN 2>/dev/null
-say "Network Map Exporter"
+SCREEN_WRITE "Network Map Exporter"
 
 RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
 mkdir -p "$RUN"
@@ -142,7 +141,7 @@ DOT="$RUN/topology.dot"
 
 if ! have nmap; then
   LED FAIL
-  say "nmap missing"
+  SCREEN_WRITE "nmap missing"
   echo "FAILED: nmap missing" > "$REPORT"
   ALERT "nmap missing" 8 2>/dev/null
   exit 1
@@ -150,7 +149,7 @@ fi
 
 # --------------------------- PASSIVE LISTEN ---------------------------------
 LED SPECIAL
-say "Passive listen"
+SCREEN_WRITE "Passive listen"
 ip link set eth0 up 2>/dev/null
 WAIT_FOR_LINK 2>/dev/null
 
@@ -201,7 +200,7 @@ SW_DESC="${L_DESC:-$C_PLAT}"
 
 # ------------------------------ DHCP ----------------------------------------
 LED STAGE1
-say "DHCP lease"
+SCREEN_WRITE "DHCP lease"
 NETMODE DHCP_CLIENT 2>/dev/null
 WAIT_FOR_LINK 2>/dev/null
 
@@ -221,7 +220,7 @@ done
 DHCP_OK=1
 if [ -z "$IP" ]; then
   DHCP_OK=0
-  say "No DHCP (passive only)"
+  SCREEN_WRITE "No DHCP (passive only)"
 fi
 
 GATEWAY=$(ip route 2>/dev/null | awk '/default/{print $3; exit}')
@@ -242,7 +241,7 @@ DOMAIN=$(grep -hE '^(search|domain)' /tmp/resolv.conf.auto /etc/resolv.conf 2>/d
 printf '%s\t%s\t%s\t%s\n' "$VLAN" "$CIDR" "1" "$GATEWAY" >> "$RUN/segments.tsv"
 
 LED STAGE2
-say "Host discovery"
+SCREEN_WRITE "Host discovery"
 NATIVE_N=0
 if [ -n "$IP" ]; then
   CREATE_SPINNER "Discover $CIDR"
@@ -262,7 +261,7 @@ done < "$RUN/passive_arp.tsv"
 # Passively sniff 802.1Q tags (a trunk leaks them; an access port shows none),
 # then optionally scan each tagged VLAN and fold its hosts into the map.
 LED STAGE4
-say "Mapping VLANs"
+SCREEN_WRITE "Mapping VLANs"
 PASSIVE_TAGS=""
 if have tcpdump; then
   CREATE_SPINNER "802.1Q listen ${PASSIVE_VLAN_SECS}s"
@@ -280,7 +279,7 @@ if [ "$SCAN_TAGGED_VLANS" = "1" ] && [ -n "$IP" ]; then
     lsmod 2>/dev/null | grep -q 8021q || modprobe 8021q 2>/dev/null
     for vid in $CANDIDATES; do
       LED STAGE5
-      say "VLAN $vid"
+      SCREEN_WRITE "VLAN $vid"
       CREATE_SPINNER "VLAN $vid: lease + scan"
       ip link add link eth0 name "eth0.$vid" type vlan id "$vid" 2>/dev/null
       if ip link show "eth0.$vid" >/dev/null 2>&1; then
@@ -311,7 +310,7 @@ SEG_COUNT=$(wc -l < "$RUN/segments.tsv" 2>/dev/null | tr -d ' ')
 
 # ----------------------------- EMIT MERMAID ---------------------------------
 LED CLEANUP
-say "Writing map"
+SCREEN_WRITE "Writing map"
 
 DROP_ID="drop"
 SWITCH_ID="switch_$(safe_id "$SWITCH")"
@@ -519,10 +518,10 @@ D_SWITCH=$(dot_txt "$SWITCH"); D_DESC=$(dot_txt "$SW_DESC"); D_PORT=$(dot_txt "$
 
 [ "$DHCP_OK" -eq 1 ] && LED FINISH || LED SPECIAL
 CLEAR_SCREEN 2>/dev/null
-say "Map export done"
-[ "$DHCP_OK" -eq 0 ] && say "Passive only (no DHCP)"
-say "Switch: $SWITCH"
-say "Hosts: $TOTAL_HOSTS"
-say "Segments: $SEG_COUNT"
+SCREEN_WRITE "Map export done"
+[ "$DHCP_OK" -eq 0 ] && SCREEN_WRITE "Passive only (no DHCP)"
+SCREEN_WRITE "Switch: $SWITCH"
+SCREEN_WRITE "Hosts: $TOTAL_HOSTS"
+SCREEN_WRITE "Segments: $SEG_COUNT"
 ALERT "Network map: $TOTAL_HOSTS hosts across $SEG_COUNT segment(s)$([ "$DHCP_OK" -eq 0 ] && echo ' (passive only)')" 12 2>/dev/null
 exit 0

--- a/payloads/library/recon/passive_listen/README.md
+++ b/payloads/library/recon/passive_listen/README.md
@@ -1,0 +1,62 @@
+# Shark Jack Display - Passive Listener
+
+Bring the link up, send (almost) nothing, and listen. In one window this
+harvests everything the switch and the neighbors broadcast for free, with no
+port scans and no unicast probes. It is the quietest opening move on an
+unfamiliar wired drop.
+
+> **Authorized use only.** Run only on networks you own or are contracted to
+> assess, within the agreed scope and time window. Nothing is exfiltrated: all
+> output stays on-device under `/root/loot/passive/` until you retrieve it.
+>
+
+## What it collects
+
+| Source | What you learn |
+|--------|----------------|
+| LLDP / CDP | switch name, model, software, the port you are patched into, native VLAN, switch management IP |
+| mDNS / SSDP / UPnP | device landscape (printers, Apple, TVs, cameras) |
+| NetBIOS / LLMNR | Windows names and naming conventions |
+| Passive ARP | live hosts with zero probes (IP + MAC + vendor) |
+| DHCP / STP | DHCP servers seen, spanning-tree presence |
+
+A single LLDP/CDP frame often describes the switching estate better than an hour
+of scanning, which is why this runs first.
+
+## Output (loot)
+
+Everything lands under `/root/loot/passive/<UTC-timestamp>_<pid>/`:
+
+```
+summary.txt        <- human-readable summary (read this first)
+capture.pcap       <- full passive capture (open in Wireshark)
+lldp.txt / cdp.txt <- full neighbor decode
+mdns.txt ssdp.txt netbios_ips.txt arp_hosts.tsv  <- per-protocol extracts
+```
+
+## Configuration (top of [`payload.txt`](payload.txt))
+
+| Knob | Default | Notes |
+|------|---------|-------|
+| `LISTEN_SECS` | `120` | capture window. LLDP/CDP announce every 30-60s, so >=90s catches a cycle |
+| `LOOT_BASE` | `/root/loot/passive` | where loot lands |
+
+## Requirements
+
+- **`tcpdump`** (not on stock firmware): `opkg update && opkg install tcpdump`.
+  `nmap` is not used by this payload.
+
+## LED / screen cues
+
+`SETUP` -> `SPECIAL` (listening) -> `STAGE1` (decoding) -> `CLEANUP` (writing
+loot) -> `FINISH`. Red `FAIL` means `tcpdump` is not installed.
+
+## Notes
+
+- Works even on 802.1X / NAC ports: it never requests an IP, so a port that will
+  not hand out a lease is no obstacle.
+- Promiscuous mode is left on intentionally so multicast control frames arrive.
+- This payload deliberately brings `eth0` up without acquiring an address
+  (`ip link set eth0 up`) so it announces nothing. There is no passive/monitor
+  `NETMODE` on this device; see the suite notes if your reviewer expects an
+  explicit `NETMODE`.

--- a/payloads/library/recon/passive_listen/payload.txt
+++ b/payloads/library/recon/passive_listen/payload.txt
@@ -1,0 +1,205 @@
+#!/bin/bash
+# ============================================================================
+#  Title:       Passive Listener (Shark Jack Display)
+#  Author:      Brent Mills
+#  Target:      An authorized wired drop, scoping a new environment.
+#  Category:    recon (passive)
+#  Version:     1.0
+# ----------------------------------------------------------------------------
+#  WHAT IT DOES
+#    Brings the link up, sends (almost) nothing, and listens. In one window it
+#    harvests the stuff a switch tells you for free:
+#      - LLDP / CDP ......... switch name, model, software, the PORT you are
+#                             patched into, native VLAN, switch management IP.
+#      - mDNS / SSDP / UPnP .. device landscape (printers, Apple, TVs, cameras).
+#      - NetBIOS / LLMNR .... Windows names + naming conventions.
+#      - Passive ARP ........ live hosts with zero probes (IP + MAC + vendor).
+#      - DHCP / STP ......... DHCP servers seen, spanning-tree presence.
+#    Keeps the full pcap plus decoded per-protocol text for later analysis.
+#
+#  WHY FIRST
+#    A single LLDP/CDP frame often describes the switching estate better than an
+#    hour of scanning, and this is about as quiet as recon gets: no port scans,
+#    no unicast probes. Ideal opening move on an unfamiliar network.
+#
+#  AUTHORIZATION
+#    Passive capture only. Runs on networks you own or are contracted to assess.
+#    Do not retain third-party payload data beyond the engagement scope. All
+#    output stays on-device in /root/loot until you pull it.
+#
+#  REQUIRES tcpdump:  opkg update && opkg install tcpdump
+# ============================================================================
+
+# ------------------------------- CONFIG -------------------------------------
+LISTEN_SECS=120                 # capture window. LLDP/CDP announce every 30-60s,
+                                # so >=90s is wise to catch at least one cycle.
+LOOT_BASE="/root/loot/passive"
+# ----------------------------------------------------------------------------
+
+# ============================ helpers =======================================
+say()  { SCREEN_WRITE "$*" 2>/dev/null; }
+glow() { LED "$@" 2>/dev/null; }
+spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
+spin_down() { STOP_SPINNER 2>/dev/null; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Lift an LLDP TLV value out of tcpdump -v output, tolerant of both formats:
+# value inline after the label's colon, OR on the following line. <file> <label>
+lldp_field() {
+  awk -v lbl="$2" '
+    index($0,lbl) {
+      rest=substr($0,index($0,lbl)); val=""
+      if (match(rest,/: /)) val=substr(rest,RSTART+2)
+      if (val ~ /^[ \t]*$/) getline val
+      gsub(/^[ \t]+|[ \t]+$/,"",val); sub(/^Subtype[^:]*: /,"",val); print val; exit
+    }' "$1" 2>/dev/null
+}
+# ============================================================================
+
+
+# ------------------------------ PHASE: SETUP --------------------------------
+glow SETUP
+CLEAR_SCREEN 2>/dev/null
+say "Passive listen starting"
+
+if ! have tcpdump; then
+  glow FAIL
+  say "tcpdump missing"
+  ALERT "Install tcpdump: opkg install tcpdump" 8 2>/dev/null
+  exit 1
+fi
+
+RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
+mkdir -p "$RUN"
+REPORT="$RUN/summary.txt"
+PCAP="$RUN/capture.pcap"
+
+# Link up, no IP: we want frames flowing without us announcing an address.
+ip link set eth0 up 2>/dev/null
+WAIT_FOR_LINK 2>/dev/null            # don't start the capture before carrier is up
+
+
+# ---------------------------- PHASE: LISTEN ---------------------------------
+glow SPECIAL
+say "Listening ${LISTEN_SECS}s"
+CREATE_PROGRESS_BAR "Capturing traffic" 2>/dev/null
+# -p would disable promisc; we WANT promisc so multicast control frames arrive.
+tcpdump -i eth0 -s 0 -w "$PCAP" 2>/dev/null &
+TPID=$!
+for i in $(seq 1 "$LISTEN_SECS"); do
+  SET_PROGRESS $(( i * 100 / LISTEN_SECS )) 2>/dev/null
+  sleep 1
+done
+kill "$TPID" 2>/dev/null; wait "$TPID" 2>/dev/null
+SET_PROGRESS 100 2>/dev/null
+
+
+# --------------------------- PHASE: DECODE ----------------------------------
+glow STAGE1
+say "Decoding capture"
+
+# --- LLDP (0x88cc) and CDP (Cisco multicast 01:00:0c:cc:cc:cc) ---
+spin_up "Switch neighbors (LLDP/CDP)"
+tcpdump -nn -v -r "$PCAP" 'ether proto 0x88cc' 2>/dev/null > "$RUN/lldp.txt"
+tcpdump -nn -v -r "$PCAP" 'ether host 01:00:0c:cc:cc:cc' 2>/dev/null > "$RUN/cdp.txt"
+spin_down
+
+# LLDP fields (best-effort; full decode kept in lldp.txt).
+L_NAME=$(lldp_field "$RUN/lldp.txt" 'System Name TLV')
+L_PORT=$(lldp_field "$RUN/lldp.txt" 'Port ID TLV')
+L_DESC=$(lldp_field "$RUN/lldp.txt" 'System Description TLV')
+L_MGMT=$(grep -i 'Management Address' "$RUN/lldp.txt" 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+L_VLAN=$(grep -iE 'PVID|Port VLAN ID' "$RUN/lldp.txt" 2>/dev/null | grep -oE '[0-9]+' | tail -1)
+
+# CDP fields.
+C_DEV=$(grep -i 'Device-ID'   "$RUN/cdp.txt" 2>/dev/null | head -1 | sed "s/.*: '//; s/'.*//")
+C_PLAT=$(grep -i 'Platform'   "$RUN/cdp.txt" 2>/dev/null | head -1 | sed "s/.*: '//; s/'.*//")
+C_PORT=$(grep -i 'Port-ID'    "$RUN/cdp.txt" 2>/dev/null | head -1 | sed "s/.*: '//; s/'.*//")
+C_NVLAN=$(grep -i 'Native VLAN' "$RUN/cdp.txt" 2>/dev/null | head -1 | grep -oE '[0-9]+' | head -1)
+C_ADDR=$(grep -iA2 'Address' "$RUN/cdp.txt" 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+
+# --- Passive ARP -> live host list (no probes sent by us) ---
+# Captures (ip, mac) from "who-has X tell <ip>" (sender) and "<ip> is-at <mac>".
+spin_up "Passive ARP hosts"
+tcpdump -nn -e -r "$PCAP" arp 2>/dev/null | awk '
+  {
+    mac=""
+    for (i=1;i<=NF;i++) if (mac=="" && $i ~ /^([0-9a-f]{2}:){5}[0-9a-f]{2}$/) mac=$i   # sender MAC
+    for (i=1;i<=NF;i++) {
+      if ($i=="tell")  { ip=$(i+1);   gsub(/[,:]$/,"",ip);   if (ip ~ /^[0-9]+\./ && mac!="") print ip"\t"mac }
+      if ($i=="is-at") { ip=$(i-1); gsub(/[,:]$/,"",ip); m=$(i+1); gsub(/[,:]$/,"",m); if (ip ~ /^[0-9]+\./ && m ~ /:/) print ip"\t"m }
+    }
+  }' | sort -u > "$RUN/arp_hosts.tsv"
+ARPN=$(wc -l < "$RUN/arp_hosts.tsv" 2>/dev/null | tr -d ' '); [ -z "$ARPN" ] && ARPN=0
+spin_down
+
+# --- mDNS / SSDP / NetBIOS / DHCP responders ---
+spin_up "mDNS / SSDP / NetBIOS"
+tcpdump -nn -r "$PCAP" 'udp port 5353' 2>/dev/null | grep -oE '[A-Za-z0-9_-]+\.(local|_tcp|_udp)' | sort -u > "$RUN/mdns.txt"
+tcpdump -nn -A -r "$PCAP" 'udp port 1900' 2>/dev/null | grep -iE '^(SERVER|LOCATION|ST|USN):' | sort -u > "$RUN/ssdp.txt"
+tcpdump -nn -r "$PCAP" 'udp port 137'  2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | sort -u > "$RUN/netbios_ips.txt"
+DHCP_SRV=$(tcpdump -nn -r "$PCAP" '(udp port 67 or udp port 68)' 2>/dev/null | grep -oiE 'Server-ID Option[^,]*[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | sort -u | tr '\n' ' ')
+STP_SEEN=$(tcpdump -nn -r "$PCAP" 'stp' 2>/dev/null | head -1)
+spin_down
+
+
+# --------------------------- PHASE: WRITE LOOT ------------------------------
+glow CLEANUP
+say "Writing loot"
+MDNSN=$(wc -l < "$RUN/mdns.txt" 2>/dev/null | tr -d ' '); [ -z "$MDNSN" ] && MDNSN=0
+{
+  echo "=========================================================="
+  echo " SHARK JACK DISPLAY - PASSIVE LISTENER"
+  echo "=========================================================="
+  echo " Run time : $(date -u '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null)"
+  echo " Window   : ${LISTEN_SECS}s passive capture on eth0"
+  echo ""
+  echo "---- SWITCH NEIGHBOR (LLDP) ------------------------------"
+  echo " System name : ${L_NAME:--}"
+  echo " Description : ${L_DESC:--}"
+  echo " Our port    : ${L_PORT:--}"
+  echo " Mgmt IP     : ${L_MGMT:--}"
+  echo " VLAN        : ${L_VLAN:--}"
+  echo ""
+  echo "---- SWITCH NEIGHBOR (CDP) -------------------------------"
+  echo " Device-ID   : ${C_DEV:--}"
+  echo " Platform    : ${C_PLAT:--}"
+  echo " Our port    : ${C_PORT:--}"
+  echo " Native VLAN : ${C_NVLAN:--}"
+  echo " Mgmt IP     : ${C_ADDR:--}"
+  echo ""
+  echo "---- INFRASTRUCTURE --------------------------------------"
+  echo " DHCP servers seen : ${DHCP_SRV:-none}"
+  echo " Spanning-tree     : $([ -n "$STP_SEEN" ] && echo "present" || echo "not seen")"
+  echo ""
+  echo "---- PASSIVE HOSTS (ARP, $ARPN seen) ---------------------"
+  if [ "$ARPN" -gt 0 ]; then
+    printf " %-15s %s\n" "IP" "MAC"
+    awk -F'\t' '{printf " %-15s %s\n",$1,$2}' "$RUN/arp_hosts.tsv"
+  else
+    echo " (none observed in window)"
+  fi
+  echo ""
+  echo "---- mDNS / BONJOUR NAMES ($MDNSN) -----------------------"
+  if [ "$MDNSN" -gt 0 ]; then sed 's/^/ /' "$RUN/mdns.txt"; else echo " (none)"; fi
+  echo ""
+  echo "---- SSDP / UPnP DEVICES ---------------------------------"
+  if [ -s "$RUN/ssdp.txt" ]; then sed 's/^/ /' "$RUN/ssdp.txt"; else echo " (none)"; fi
+  echo ""
+  echo "---- RAW ARTIFACTS ---------------------------------------"
+  echo " capture.pcap   - full passive capture (open in Wireshark)"
+  echo " lldp.txt / cdp.txt - full neighbor decode"
+  echo " mdns/ssdp/netbios/arp_hosts - per-protocol extracts"
+  echo "=========================================================="
+} > "$REPORT"
+
+
+# ------------------------------ PHASE: DONE ---------------------------------
+glow FINISH
+NEIGH="${L_NAME:-$C_DEV}"
+CLEAR_SCREEN 2>/dev/null
+say "Passive listen done"
+say "Switch: ${NEIGH:-unknown}"
+say "Hosts(ARP): $ARPN"
+ALERT "Passive done. Switch: ${NEIGH:-?}, $ARPN hosts seen." 12 2>/dev/null
+exit 0

--- a/payloads/library/recon/passive_listen/payload.txt
+++ b/payloads/library/recon/passive_listen/payload.txt
@@ -39,7 +39,6 @@ LOOT_BASE="/root/loot/passive"
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-glow() { LED "$@" 2>/dev/null; }
 spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
@@ -59,12 +58,12 @@ lldp_field() {
 
 
 # ------------------------------ PHASE: SETUP --------------------------------
-glow SETUP
+LED SETUP
 CLEAR_SCREEN 2>/dev/null
 say "Passive listen starting"
 
 if ! have tcpdump; then
-  glow FAIL
+  LED FAIL
   say "tcpdump missing"
   ALERT "Install tcpdump: opkg install tcpdump" 8 2>/dev/null
   exit 1
@@ -81,7 +80,7 @@ WAIT_FOR_LINK 2>/dev/null            # don't start the capture before carrier is
 
 
 # ---------------------------- PHASE: LISTEN ---------------------------------
-glow SPECIAL
+LED SPECIAL
 say "Listening ${LISTEN_SECS}s"
 CREATE_PROGRESS_BAR "Capturing traffic" 2>/dev/null
 # -p would disable promisc; we WANT promisc so multicast control frames arrive.
@@ -96,7 +95,7 @@ SET_PROGRESS 100 2>/dev/null
 
 
 # --------------------------- PHASE: DECODE ----------------------------------
-glow STAGE1
+LED STAGE1
 say "Decoding capture"
 
 # --- LLDP (0x88cc) and CDP (Cisco multicast 01:00:0c:cc:cc:cc) ---
@@ -145,7 +144,7 @@ spin_down
 
 
 # --------------------------- PHASE: WRITE LOOT ------------------------------
-glow CLEANUP
+LED CLEANUP
 say "Writing loot"
 MDNSN=$(wc -l < "$RUN/mdns.txt" 2>/dev/null | tr -d ' '); [ -z "$MDNSN" ] && MDNSN=0
 {
@@ -196,7 +195,7 @@ MDNSN=$(wc -l < "$RUN/mdns.txt" 2>/dev/null | tr -d ' '); [ -z "$MDNSN" ] && MDN
 
 
 # ------------------------------ PHASE: DONE ---------------------------------
-glow FINISH
+LED FINISH
 NEIGH="${L_NAME:-$C_DEV}"
 CLEAR_SCREEN 2>/dev/null
 say "Passive listen done"

--- a/payloads/library/recon/passive_listen/payload.txt
+++ b/payloads/library/recon/passive_listen/payload.txt
@@ -5,6 +5,7 @@
 #  Target:      An authorized wired drop, scoping a new environment.
 #  Category:    recon (passive)
 #  Version:     1.0
+#  Firmware:    Tested on Shark Jack Display 1.0.1
 # ----------------------------------------------------------------------------
 #  WHAT IT DOES
 #    Brings the link up, sends (almost) nothing, and listens. In one window it

--- a/payloads/library/recon/passive_listen/payload.txt
+++ b/payloads/library/recon/passive_listen/payload.txt
@@ -39,7 +39,6 @@ LOOT_BASE="/root/loot/passive"
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
@@ -99,7 +98,7 @@ LED STAGE1
 say "Decoding capture"
 
 # --- LLDP (0x88cc) and CDP (Cisco multicast 01:00:0c:cc:cc:cc) ---
-spin_up "Switch neighbors (LLDP/CDP)"
+CREATE_SPINNER "Switch neighbors (LLDP/CDP)"
 tcpdump -nn -v -r "$PCAP" 'ether proto 0x88cc' 2>/dev/null > "$RUN/lldp.txt"
 tcpdump -nn -v -r "$PCAP" 'ether host 01:00:0c:cc:cc:cc' 2>/dev/null > "$RUN/cdp.txt"
 spin_down
@@ -120,7 +119,7 @@ C_ADDR=$(grep -iA2 'Address' "$RUN/cdp.txt" 2>/dev/null | grep -oE '[0-9]+\.[0-9
 
 # --- Passive ARP -> live host list (no probes sent by us) ---
 # Captures (ip, mac) from "who-has X tell <ip>" (sender) and "<ip> is-at <mac>".
-spin_up "Passive ARP hosts"
+CREATE_SPINNER "Passive ARP hosts"
 tcpdump -nn -e -r "$PCAP" arp 2>/dev/null | awk '
   {
     mac=""
@@ -134,7 +133,7 @@ ARPN=$(wc -l < "$RUN/arp_hosts.tsv" 2>/dev/null | tr -d ' '); [ -z "$ARPN" ] && 
 spin_down
 
 # --- mDNS / SSDP / NetBIOS / DHCP responders ---
-spin_up "mDNS / SSDP / NetBIOS"
+CREATE_SPINNER "mDNS / SSDP / NetBIOS"
 tcpdump -nn -r "$PCAP" 'udp port 5353' 2>/dev/null | grep -oE '[A-Za-z0-9_-]+\.(local|_tcp|_udp)' | sort -u > "$RUN/mdns.txt"
 tcpdump -nn -A -r "$PCAP" 'udp port 1900' 2>/dev/null | grep -iE '^(SERVER|LOCATION|ST|USN):' | sort -u > "$RUN/ssdp.txt"
 tcpdump -nn -r "$PCAP" 'udp port 137'  2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | sort -u > "$RUN/netbios_ips.txt"

--- a/payloads/library/recon/passive_listen/payload.txt
+++ b/payloads/library/recon/passive_listen/payload.txt
@@ -38,7 +38,6 @@ LOOT_BASE="/root/loot/passive"
 # ----------------------------------------------------------------------------
 
 # ============================ helpers =======================================
-say()  { SCREEN_WRITE "$*" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
 # Lift an LLDP TLV value out of tcpdump -v output, tolerant of both formats:
@@ -58,11 +57,11 @@ lldp_field() {
 # ------------------------------ PHASE: SETUP --------------------------------
 LED SETUP
 CLEAR_SCREEN 2>/dev/null
-say "Passive listen starting"
+SCREEN_WRITE "Passive listen starting"
 
 if ! have tcpdump; then
   LED FAIL
-  say "tcpdump missing"
+  SCREEN_WRITE "tcpdump missing"
   ALERT "Install tcpdump: opkg install tcpdump" 8 2>/dev/null
   exit 1
 fi
@@ -79,7 +78,7 @@ WAIT_FOR_LINK 2>/dev/null            # don't start the capture before carrier is
 
 # ---------------------------- PHASE: LISTEN ---------------------------------
 LED SPECIAL
-say "Listening ${LISTEN_SECS}s"
+SCREEN_WRITE "Listening ${LISTEN_SECS}s"
 CREATE_PROGRESS_BAR "Capturing traffic" 2>/dev/null
 # -p would disable promisc; we WANT promisc so multicast control frames arrive.
 tcpdump -i eth0 -s 0 -w "$PCAP" 2>/dev/null &
@@ -94,7 +93,7 @@ SET_PROGRESS 100 2>/dev/null
 
 # --------------------------- PHASE: DECODE ----------------------------------
 LED STAGE1
-say "Decoding capture"
+SCREEN_WRITE "Decoding capture"
 
 # --- LLDP (0x88cc) and CDP (Cisco multicast 01:00:0c:cc:cc:cc) ---
 CREATE_SPINNER "Switch neighbors (LLDP/CDP)"
@@ -143,7 +142,7 @@ STOP_SPINNER
 
 # --------------------------- PHASE: WRITE LOOT ------------------------------
 LED CLEANUP
-say "Writing loot"
+SCREEN_WRITE "Writing loot"
 MDNSN=$(wc -l < "$RUN/mdns.txt" 2>/dev/null | tr -d ' '); [ -z "$MDNSN" ] && MDNSN=0
 {
   echo "=========================================================="
@@ -196,8 +195,8 @@ MDNSN=$(wc -l < "$RUN/mdns.txt" 2>/dev/null | tr -d ' '); [ -z "$MDNSN" ] && MDN
 LED FINISH
 NEIGH="${L_NAME:-$C_DEV}"
 CLEAR_SCREEN 2>/dev/null
-say "Passive listen done"
-say "Switch: ${NEIGH:-unknown}"
-say "Hosts(ARP): $ARPN"
+SCREEN_WRITE "Passive listen done"
+SCREEN_WRITE "Switch: ${NEIGH:-unknown}"
+SCREEN_WRITE "Hosts(ARP): $ARPN"
 ALERT "Passive done. Switch: ${NEIGH:-?}, $ARPN hosts seen." 12 2>/dev/null
 exit 0

--- a/payloads/library/recon/passive_listen/payload.txt
+++ b/payloads/library/recon/passive_listen/payload.txt
@@ -39,7 +39,6 @@ LOOT_BASE="/root/loot/passive"
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
 # Lift an LLDP TLV value out of tcpdump -v output, tolerant of both formats:
@@ -101,7 +100,7 @@ say "Decoding capture"
 CREATE_SPINNER "Switch neighbors (LLDP/CDP)"
 tcpdump -nn -v -r "$PCAP" 'ether proto 0x88cc' 2>/dev/null > "$RUN/lldp.txt"
 tcpdump -nn -v -r "$PCAP" 'ether host 01:00:0c:cc:cc:cc' 2>/dev/null > "$RUN/cdp.txt"
-spin_down
+STOP_SPINNER
 
 # LLDP fields (best-effort; full decode kept in lldp.txt).
 L_NAME=$(lldp_field "$RUN/lldp.txt" 'System Name TLV')
@@ -130,7 +129,7 @@ tcpdump -nn -e -r "$PCAP" arp 2>/dev/null | awk '
     }
   }' | sort -u > "$RUN/arp_hosts.tsv"
 ARPN=$(wc -l < "$RUN/arp_hosts.tsv" 2>/dev/null | tr -d ' '); [ -z "$ARPN" ] && ARPN=0
-spin_down
+STOP_SPINNER
 
 # --- mDNS / SSDP / NetBIOS / DHCP responders ---
 CREATE_SPINNER "mDNS / SSDP / NetBIOS"
@@ -139,7 +138,7 @@ tcpdump -nn -A -r "$PCAP" 'udp port 1900' 2>/dev/null | grep -iE '^(SERVER|LOCAT
 tcpdump -nn -r "$PCAP" 'udp port 137'  2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | sort -u > "$RUN/netbios_ips.txt"
 DHCP_SRV=$(tcpdump -nn -r "$PCAP" '(udp port 67 or udp port 68)' 2>/dev/null | grep -oiE 'Server-ID Option[^,]*[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | sort -u | tr '\n' ' ')
 STP_SEEN=$(tcpdump -nn -r "$PCAP" 'stp' 2>/dev/null | head -1)
-spin_down
+STOP_SPINNER
 
 
 # --------------------------- PHASE: WRITE LOOT ------------------------------

--- a/payloads/library/recon/poe_survey/README.md
+++ b/payloads/library/recon/poe_survey/README.md
@@ -1,0 +1,91 @@
+# Shark Jack Display - PoE Survey
+
+Tells you the Power-over-Ethernet posture of a drop before you commit an access
+point, IP camera, or any other powered device to it: is the port PoE-capable, at
+what class/type, and what power budget. It does this **passively**, by reading
+what the switch advertises over LLDP and CDP, the same negotiation APs and
+cameras themselves use.
+
+> **Read this first: what this can and cannot do.** The Shark Jack is not a PoE
+> powered device and has **no way to electrically measure** line voltage or
+> current. Its NIC magnetics block DC, and it presents no PD signature, so a
+> compliant switch never even energizes the port (which is also why this is
+> safe). This payload therefore does **not** meter power. It reports what the
+> switch *advertises* over LLDP/CDP, which is authoritative for what the port
+> will negotiate, but only exists if the switch runs LLDP/CDP and advertises
+> power. When nothing is advertised, the result is **inconclusive** and you
+> should confirm with a hardware PoE tester.
+
+> **Authorized use only.** Passive capture: no probes, no scans, no DHCP. Run
+> only on networks you own or are contracted to assess, within the agreed scope
+> and time window. Nothing is exfiltrated: all output stays on-device under
+> `/root/loot/poe_survey/` until you retrieve it. See the Legal and Disclaimer
+> sections of the repository README.
+
+## What it reads
+
+| Question | Source |
+|----------|--------|
+| **PoE present?** | LLDP 802.3 *Power-via-MDI* TLV: PSE-capable + power state (enabled/disabled), or a CDP power TLV |
+| **PoE class / type?** | the advertised class (0-4); the payload maps it to its 802.3af/at power envelope |
+| **Power budget?** | LLDP *Extended Power-via-MDI* PSE-allocated / PD-requested watts (0.1 W units), and Cisco CDP "Power Available" (mW) |
+
+The report always prints the **raw power TLV lines** alongside the parsed values,
+so you can see exactly what the switch said rather than trusting the parse.
+
+## The verdict
+
+| Verdict | Meaning |
+|---------|---------|
+| **PoE AVAILABLE** | the switch advertised PoE power on this port (LLDP and/or CDP). Class and watts are reported |
+| **INCONCLUSIVE** | LLDP/CDP were heard but carried no power TLV. The port may be non-PoE, or PoE is simply not advertised. Confirm with a hardware PoE tester |
+| **UNKNOWN** | no LLDP/CDP heard at all (unmanaged switch, a dumb injector, or LLDP/CDP disabled). Use a hardware PoE tester |
+
+`INCONCLUSIVE` and `UNKNOWN` are honest outcomes, not failures: a passive read
+cannot prove the *absence* of PoE, only confirm what is advertised.
+
+## Output (loot)
+
+`/root/loot/poe_survey/<UTC-timestamp>_<pid>/`:
+
+```
+summary.txt        <- verdict + parsed power + raw TLV lines (read this first)
+capture.pcap       <- full passive capture (open in Wireshark)
+lldp.txt / cdp.txt <- full neighbor decode
+poe_lldp.txt / poe_cdp.txt <- the extracted power lines
+```
+
+## Configuration (top of [`payload.txt`](payload.txt))
+
+| Knob | Default | Notes |
+|------|---------|-------|
+| `LISTEN_SECS` | `120` | capture window. LLDP carries the power TLV every ~30s and CDP every ~60s, so `>=90s` catches a couple cycles |
+| `LOOT_BASE` | `/root/loot/poe_survey` | where loot lands |
+
+## Requirements
+
+- **`tcpdump`** (not on stock firmware): `opkg update && opkg install tcpdump`.
+  `nmap` is not used, this payload never scans.
+
+## LED / screen cues
+
+`SETUP` -> `SPECIAL` (listening, with a progress bar) -> `STAGE1` (reading power
+TLVs) -> `CLEANUP` (writing loot) -> verdict LED. Green `FINISH` means **PoE
+AVAILABLE**; amber `SPECIAL` means **INCONCLUSIVE** or **UNKNOWN**; red `FAIL`
+means `tcpdump` is not installed. The final `ALERT` carries the verdict, class,
+and allocated watts.
+
+## Notes / accuracy
+
+- **It reflects advertisement, not metering.** On a managed switch with LLDP-MED
+  (common on AP/voice access ports) you will typically get class and allocated
+  watts. On a switch that advertises only capability (not a live allocation),
+  the class-to-power envelope is your guide to the budget.
+- **Works on 802.1X / NAC ports**: it never requests an IP, so a locked-down port
+  is no obstacle to reading LLDP/CDP.
+- **Watts units**: LLDP power values are 0.1 W per 802.3at (the report shows both
+  the raw value and the converted watts); CDP power is milliwatts.
+- For a port behind a **dumb PoE injector** or an unmanaged PoE switch, there is
+  no advertisement to read, so this returns `UNKNOWN`. That is the one case where
+  only a hardware PoE tester (or actually plugging in the target device) will
+  tell you.

--- a/payloads/library/recon/poe_survey/README.md
+++ b/payloads/library/recon/poe_survey/README.md
@@ -19,8 +19,7 @@ cameras themselves use.
 > **Authorized use only.** Passive capture: no probes, no scans, no DHCP. Run
 > only on networks you own or are contracted to assess, within the agreed scope
 > and time window. Nothing is exfiltrated: all output stays on-device under
-> `/root/loot/poe_survey/` until you retrieve it. See the Legal and Disclaimer
-> sections of the repository README.
+> `/root/loot/poe_survey/` until you retrieve it.
 
 ## What it reads
 

--- a/payloads/library/recon/poe_survey/payload.txt
+++ b/payloads/library/recon/poe_survey/payload.txt
@@ -5,6 +5,7 @@
 #  Target:      An authorized wired drop you are evaluating for PoE.
 #  Category:    recon (passive)
 #  Version:     1.0
+#  Firmware:    Tested on Shark Jack Display 1.0.1
 # ----------------------------------------------------------------------------
 #  WHAT IT DOES
 #    Reports the Power-over-Ethernet posture of a drop by passively reading what

--- a/payloads/library/recon/poe_survey/payload.txt
+++ b/payloads/library/recon/poe_survey/payload.txt
@@ -41,7 +41,6 @@ LOOT_BASE="/root/loot/poe_survey"
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-glow() { LED "$@" 2>/dev/null; }
 spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
@@ -72,12 +71,12 @@ class_power() {
 
 
 # ------------------------------ PHASE: SETUP --------------------------------
-glow SETUP
+LED SETUP
 CLEAR_SCREEN 2>/dev/null
 say "PoE Survey"
 
 if ! have tcpdump; then
-  glow FAIL
+  LED FAIL
   say "tcpdump missing"
   ALERT "Install tcpdump: opkg install tcpdump" 8 2>/dev/null
   exit 1
@@ -94,7 +93,7 @@ WAIT_FOR_LINK 2>/dev/null
 
 
 # ---------------------------- PHASE: LISTEN ---------------------------------
-glow SPECIAL
+LED SPECIAL
 say "Listening ${LISTEN_SECS}s"
 CREATE_PROGRESS_BAR "Capturing LLDP/CDP" 2>/dev/null
 tcpdump -i eth0 -s 0 -w "$PCAP" 2>/dev/null &
@@ -108,7 +107,7 @@ SET_PROGRESS 100 2>/dev/null
 
 
 # --------------------------- PHASE: DECODE ----------------------------------
-glow STAGE1
+LED STAGE1
 say "Reading power TLVs"
 spin_up "LLDP / CDP power"
 
@@ -175,7 +174,7 @@ fi
 
 
 # --------------------------- PHASE: WRITE LOOT ------------------------------
-glow CLEANUP
+LED CLEANUP
 say "Writing loot"
 spin_down
 {
@@ -227,7 +226,7 @@ spin_down
 
 
 # ------------------------------ PHASE: DONE ---------------------------------
-glow "$VLED"
+LED "$VLED"
 CLEAR_SCREEN 2>/dev/null
 say "PoE: $VERDICT"
 [ "$VERDICT" = "PoE AVAILABLE" ] && say "Class: ${POE_CLASS:--}"

--- a/payloads/library/recon/poe_survey/payload.txt
+++ b/payloads/library/recon/poe_survey/payload.txt
@@ -1,0 +1,237 @@
+#!/bin/bash
+# ============================================================================
+#  Title:       PoE Survey (Shark Jack Display)
+#  Author:      Brent Mills
+#  Target:      An authorized wired drop you are evaluating for PoE.
+#  Category:    recon (passive)
+#  Version:     1.0
+# ----------------------------------------------------------------------------
+#  WHAT IT DOES
+#    Reports the Power-over-Ethernet posture of a drop by passively reading what
+#    the switch advertises, the same negotiation APs and cameras use:
+#      - PoE present?  .... is the port PSE-capable, and is power enabled?
+#      - PoE class?    .... advertised class (0-4) and type (802.3af/at/bt).
+#      - Power budget? .... PSE allocated / available watts (LLDP and CDP).
+#    Useful when planning AP or IP-camera deployments, or any time a drop has to
+#    deliver PoE before you commit hardware to it.
+#
+#  HARDWARE NOTE (read this)
+#    The Shark Jack is NOT a PoE powered device and has no way to electrically
+#    measure line voltage (its NIC magnetics block DC, and it presents no PD
+#    signature so a compliant switch never energizes it). This payload therefore
+#    does NOT measure power. It reports what the switch ADVERTISES over LLDP /
+#    CDP, which is authoritative for what the port will negotiate, but only
+#    exists if the switch runs LLDP/CDP and advertises power. If nothing is
+#    advertised the result is INCONCLUSIVE: confirm with a hardware PoE tester.
+#
+#  AUTHORIZATION
+#    Passive capture only (no probes, no scans, no DHCP). Run on networks you own
+#    or are contracted to assess, within scope. Output stays on-device in
+#    /root/loot until you pull it.
+#
+#  REQUIRES tcpdump:  opkg update && opkg install tcpdump
+# ============================================================================
+
+# ------------------------------- CONFIG -------------------------------------
+LISTEN_SECS=120                 # LLDP carries the power TLV every ~30s and CDP
+                                # every ~60s, so >=90s catches a couple cycles.
+LOOT_BASE="/root/loot/poe_survey"
+# ----------------------------------------------------------------------------
+
+# ============================ helpers =======================================
+say()  { SCREEN_WRITE "$*" 2>/dev/null; }
+glow() { LED "$@" 2>/dev/null; }
+spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
+spin_down() { STOP_SPINNER 2>/dev/null; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+lldp_field() {
+  awk -v lbl="$2" '
+    index($0,lbl) {
+      rest=substr($0,index($0,lbl)); val=""
+      if (match(rest,/: /)) val=substr(rest,RSTART+2)
+      if (val ~ /^[ \t]*$/) getline val
+      gsub(/^[ \t]+|[ \t]+$/,"",val); sub(/^Subtype[^:]*: /,"",val); print val; exit
+    }' "$1" 2>/dev/null
+}
+
+# Translate an 802.3 PoE class digit to its PD power envelope (handy when only a
+# class is advertised, with no explicit allocated-watts value).
+class_power() {
+  case "$1" in
+    0) echo "<= 12.95 W (Class 0, Type 1)" ;;
+    1) echo "<= 3.84 W (Class 1, Type 1)" ;;
+    2) echo "<= 6.49 W (Class 2, Type 1)" ;;
+    3) echo "<= 12.95 W (Class 3, Type 1)" ;;
+    4) echo "<= 25.5 W (Class 4, Type 2 / 802.3at)" ;;
+    *) echo "-" ;;
+  esac
+}
+# ============================================================================
+
+
+# ------------------------------ PHASE: SETUP --------------------------------
+glow SETUP
+CLEAR_SCREEN 2>/dev/null
+say "PoE Survey"
+
+if ! have tcpdump; then
+  glow FAIL
+  say "tcpdump missing"
+  ALERT "Install tcpdump: opkg install tcpdump" 8 2>/dev/null
+  exit 1
+fi
+
+RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
+mkdir -p "$RUN"
+REPORT="$RUN/summary.txt"
+PCAP="$RUN/capture.pcap"
+
+# Link up, no IP: passive only.
+ip link set eth0 up 2>/dev/null
+WAIT_FOR_LINK 2>/dev/null
+
+
+# ---------------------------- PHASE: LISTEN ---------------------------------
+glow SPECIAL
+say "Listening ${LISTEN_SECS}s"
+CREATE_PROGRESS_BAR "Capturing LLDP/CDP" 2>/dev/null
+tcpdump -i eth0 -s 0 -w "$PCAP" 2>/dev/null &
+TPID=$!
+for i in $(seq 1 "$LISTEN_SECS"); do
+  SET_PROGRESS $(( i * 100 / LISTEN_SECS )) 2>/dev/null
+  sleep 1
+done
+kill "$TPID" 2>/dev/null; wait "$TPID" 2>/dev/null
+SET_PROGRESS 100 2>/dev/null
+
+
+# --------------------------- PHASE: DECODE ----------------------------------
+glow STAGE1
+say "Reading power TLVs"
+spin_up "LLDP / CDP power"
+
+tcpdump -nn -v -r "$PCAP" 'ether proto 0x88cc' 2>/dev/null > "$RUN/lldp.txt"
+tcpdump -nn -v -r "$PCAP" 'ether host 01:00:0c:cc:cc:cc' 2>/dev/null > "$RUN/cdp.txt"
+
+L_NAME=$(lldp_field "$RUN/lldp.txt" 'System Name TLV')
+L_PORT=$(lldp_field "$RUN/lldp.txt" 'Port ID TLV')
+C_DEV=$(grep -i 'Device-ID' "$RUN/cdp.txt" 2>/dev/null | head -1 | sed "s/.*: '//; s/'.*//")
+
+LLDP_SEEN=no; [ -s "$RUN/lldp.txt" ] && LLDP_SEEN=yes
+CDP_SEEN=no;  [ -s "$RUN/cdp.txt" ]  && CDP_SEEN=yes
+
+# Pull just the power-relevant lines so the report can show ground truth, and so
+# parsing is tolerant of tcpdump wording differences across versions.
+grep -iE 'power|MDI' "$RUN/lldp.txt" 2>/dev/null > "$RUN/poe_lldp.txt"
+grep -iE 'power'      "$RUN/cdp.txt"  2>/dev/null > "$RUN/poe_cdp.txt"
+
+# --- LLDP 802.3 Power-via-MDI / Extended Power-via-MDI ---
+POWER_TLV=no
+grep -iqE 'power via mdi|power pair|MDI power|allocated power|requested power|power class|power type' \
+  "$RUN/poe_lldp.txt" && POWER_TLV=yes
+
+PSE_CAP="-"
+grep -iqE '\bPSE\b' "$RUN/poe_lldp.txt" && PSE_CAP="yes (PSE advertised)"
+POE_STATE="-"
+grep -iqE 'enabled'  "$RUN/poe_lldp.txt" && POE_STATE="enabled"
+grep -iqE 'disabled' "$RUN/poe_lldp.txt" && POE_STATE="disabled"
+
+POE_CLASS=$(grep -ioE 'class[ ]?[0-9]' "$RUN/poe_lldp.txt" | head -1)
+CLASS_NUM=$(printf '%s' "$POE_CLASS" | grep -oE '[0-9]' | head -1)
+CLASS_ENVELOPE=$(class_power "${CLASS_NUM:-x}")
+
+POE_TYPE=$(grep -ioE 'power type[^,]*' "$RUN/poe_lldp.txt" | head -1)
+POE_PAIR=$(grep -ioE 'power pair[^,]*' "$RUN/poe_lldp.txt" | head -1)
+
+# 802.3at power values are in 0.1 W units. Require the number to follow the
+# label directly (a colon or spaces) so we read the value, not a TLV header.
+ALLOC=$(grep -ioE 'allocated power value[: ]+[0-9]+' "$RUN/poe_lldp.txt" | grep -oE '[0-9]+$' | head -1)
+REQ=$(grep -ioE 'requested power value[: ]+[0-9]+'   "$RUN/poe_lldp.txt" | grep -oE '[0-9]+$' | head -1)
+ALLOC_W="-"; [ -n "$ALLOC" ] && ALLOC_W=$(awk -v a="$ALLOC" 'BEGIN{printf "%.1f W", a/10}')
+REQ_W="-";   [ -n "$REQ" ]   && REQ_W=$(awk -v a="$REQ" 'BEGIN{printf "%.1f W", a/10}')
+
+# --- CDP power (Cisco): values are in milliwatts. "Power Available" appears both
+# as the TLV name and before the value, so anchor on the number that follows. ---
+CDP_AVAIL=$(grep -ioE 'power available[: ]+[0-9]+' "$RUN/poe_cdp.txt" | grep -oE '[0-9]+$' | head -1)
+CDP_AVAIL_W="-"; [ -n "$CDP_AVAIL" ] && CDP_AVAIL_W=$(awk -v a="$CDP_AVAIL" 'BEGIN{printf "%.1f W", a/1000}')
+
+
+# --------------------------- PHASE: VERDICT ---------------------------------
+if [ "$POWER_TLV" = "yes" ] || [ -n "$CDP_AVAIL" ]; then
+  VERDICT="PoE AVAILABLE"
+  REASON="switch advertises PoE power on this port (LLDP/CDP)"
+  VLED="FINISH"
+elif [ "$LLDP_SEEN" = "yes" ] || [ "$CDP_SEEN" = "yes" ]; then
+  VERDICT="INCONCLUSIVE"
+  REASON="LLDP/CDP heard but no power TLV; port may be non-PoE, or PoE simply not advertised. Confirm with a hardware PoE tester."
+  VLED="SPECIAL"
+else
+  VERDICT="UNKNOWN"
+  REASON="no LLDP/CDP heard; unmanaged switch, a dumb injector, or LLDP/CDP disabled. Use a hardware PoE tester."
+  VLED="SPECIAL"
+fi
+
+
+# --------------------------- PHASE: WRITE LOOT ------------------------------
+glow CLEANUP
+say "Writing loot"
+spin_down
+{
+  echo "=========================================================="
+  echo " SHARK JACK DISPLAY - PoE SURVEY"
+  echo "=========================================================="
+  echo " Run time : $(date -u '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null)"
+  echo " Window   : ${LISTEN_SECS}s passive capture on eth0"
+  echo ""
+  echo "---- VERDICT ---------------------------------------------"
+  echo " PoE      : $VERDICT"
+  echo " Reason   : $REASON"
+  echo ""
+  echo "---- LLDP POWER-VIA-MDI ----------------------------------"
+  echo " LLDP heard      : $LLDP_SEEN"
+  echo " Power TLV        : $POWER_TLV"
+  echo " PSE capable      : $PSE_CAP"
+  echo " Power state      : $POE_STATE"
+  echo " Class            : ${POE_CLASS:--}  ($CLASS_ENVELOPE)"
+  echo " ${POE_TYPE:-Power type -}"
+  echo " ${POE_PAIR:-Power pair -}"
+  echo " PD requested     : ${REQ_W} (raw ${REQ:--}, 0.1W units)"
+  echo " PSE allocated    : ${ALLOC_W} (raw ${ALLOC:--}, 0.1W units)"
+  echo ""
+  echo "---- CDP POWER (Cisco) -----------------------------------"
+  echo " CDP heard       : $CDP_SEEN"
+  echo " Power available  : ${CDP_AVAIL_W} (raw ${CDP_AVAIL:--} mW)"
+  echo ""
+  echo "---- SWITCH / PORT (for locating the drop) ---------------"
+  echo " LLDP system name : ${L_NAME:--}"
+  echo " LLDP our port    : ${L_PORT:--}"
+  echo " CDP device       : ${C_DEV:--}"
+  echo ""
+  echo "---- RAW POWER TLV LINES (ground truth) ------------------"
+  if [ -s "$RUN/poe_lldp.txt" ]; then sed 's/^/ /' "$RUN/poe_lldp.txt"; else echo " (no LLDP power lines)"; fi
+  if [ -s "$RUN/poe_cdp.txt" ];  then sed 's/^/ /' "$RUN/poe_cdp.txt";  fi
+  echo ""
+  echo "---- HARDWARE NOTE ---------------------------------------"
+  echo " The Shark Jack cannot electrically measure PoE; these values are READ"
+  echo " from the switch's LLDP/CDP advertisements, not metered. For ground"
+  echo " truth on an unmanaged port, use a hardware PoE tester."
+  echo ""
+  echo "---- RAW ARTIFACTS ---------------------------------------"
+  echo " capture.pcap         - full passive capture (open in Wireshark)"
+  echo " lldp.txt / cdp.txt   - full neighbor decode"
+  echo " poe_lldp.txt / poe_cdp.txt - extracted power lines"
+  echo "=========================================================="
+} > "$REPORT"
+
+
+# ------------------------------ PHASE: DONE ---------------------------------
+glow "$VLED"
+CLEAR_SCREEN 2>/dev/null
+say "PoE: $VERDICT"
+[ "$VERDICT" = "PoE AVAILABLE" ] && say "Class: ${POE_CLASS:--}"
+[ "$ALLOC_W" != "-" ] && say "Alloc: $ALLOC_W"
+[ "$ALLOC_W" = "-" ] && [ "$CDP_AVAIL_W" != "-" ] && say "Avail: $CDP_AVAIL_W"
+say "Sw: ${L_NAME:-${C_DEV:-unknown}}"
+ALERT "PoE Survey: $VERDICT (class ${POE_CLASS:--}, alloc ${ALLOC_W})" 12 2>/dev/null
+exit 0

--- a/payloads/library/recon/poe_survey/payload.txt
+++ b/payloads/library/recon/poe_survey/payload.txt
@@ -41,7 +41,6 @@ LOOT_BASE="/root/loot/poe_survey"
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
 lldp_field() {
@@ -175,7 +174,7 @@ fi
 # --------------------------- PHASE: WRITE LOOT ------------------------------
 LED CLEANUP
 say "Writing loot"
-spin_down
+STOP_SPINNER
 {
   echo "=========================================================="
   echo " SHARK JACK DISPLAY - PoE SURVEY"

--- a/payloads/library/recon/poe_survey/payload.txt
+++ b/payloads/library/recon/poe_survey/payload.txt
@@ -41,7 +41,6 @@ LOOT_BASE="/root/loot/poe_survey"
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
@@ -109,7 +108,7 @@ SET_PROGRESS 100 2>/dev/null
 # --------------------------- PHASE: DECODE ----------------------------------
 LED STAGE1
 say "Reading power TLVs"
-spin_up "LLDP / CDP power"
+CREATE_SPINNER "LLDP / CDP power"
 
 tcpdump -nn -v -r "$PCAP" 'ether proto 0x88cc' 2>/dev/null > "$RUN/lldp.txt"
 tcpdump -nn -v -r "$PCAP" 'ether host 01:00:0c:cc:cc:cc' 2>/dev/null > "$RUN/cdp.txt"

--- a/payloads/library/recon/poe_survey/payload.txt
+++ b/payloads/library/recon/poe_survey/payload.txt
@@ -40,7 +40,6 @@ LOOT_BASE="/root/loot/poe_survey"
 # ----------------------------------------------------------------------------
 
 # ============================ helpers =======================================
-say()  { SCREEN_WRITE "$*" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
 lldp_field() {
@@ -71,11 +70,11 @@ class_power() {
 # ------------------------------ PHASE: SETUP --------------------------------
 LED SETUP
 CLEAR_SCREEN 2>/dev/null
-say "PoE Survey"
+SCREEN_WRITE "PoE Survey"
 
 if ! have tcpdump; then
   LED FAIL
-  say "tcpdump missing"
+  SCREEN_WRITE "tcpdump missing"
   ALERT "Install tcpdump: opkg install tcpdump" 8 2>/dev/null
   exit 1
 fi
@@ -92,7 +91,7 @@ WAIT_FOR_LINK 2>/dev/null
 
 # ---------------------------- PHASE: LISTEN ---------------------------------
 LED SPECIAL
-say "Listening ${LISTEN_SECS}s"
+SCREEN_WRITE "Listening ${LISTEN_SECS}s"
 CREATE_PROGRESS_BAR "Capturing LLDP/CDP" 2>/dev/null
 tcpdump -i eth0 -s 0 -w "$PCAP" 2>/dev/null &
 TPID=$!
@@ -106,7 +105,7 @@ SET_PROGRESS 100 2>/dev/null
 
 # --------------------------- PHASE: DECODE ----------------------------------
 LED STAGE1
-say "Reading power TLVs"
+SCREEN_WRITE "Reading power TLVs"
 CREATE_SPINNER "LLDP / CDP power"
 
 tcpdump -nn -v -r "$PCAP" 'ether proto 0x88cc' 2>/dev/null > "$RUN/lldp.txt"
@@ -173,7 +172,7 @@ fi
 
 # --------------------------- PHASE: WRITE LOOT ------------------------------
 LED CLEANUP
-say "Writing loot"
+SCREEN_WRITE "Writing loot"
 STOP_SPINNER
 {
   echo "=========================================================="
@@ -226,10 +225,10 @@ STOP_SPINNER
 # ------------------------------ PHASE: DONE ---------------------------------
 LED "$VLED"
 CLEAR_SCREEN 2>/dev/null
-say "PoE: $VERDICT"
-[ "$VERDICT" = "PoE AVAILABLE" ] && say "Class: ${POE_CLASS:--}"
-[ "$ALLOC_W" != "-" ] && say "Alloc: $ALLOC_W"
-[ "$ALLOC_W" = "-" ] && [ "$CDP_AVAIL_W" != "-" ] && say "Avail: $CDP_AVAIL_W"
-say "Sw: ${L_NAME:-${C_DEV:-unknown}}"
+SCREEN_WRITE "PoE: $VERDICT"
+[ "$VERDICT" = "PoE AVAILABLE" ] && SCREEN_WRITE "Class: ${POE_CLASS:--}"
+[ "$ALLOC_W" != "-" ] && SCREEN_WRITE "Alloc: $ALLOC_W"
+[ "$ALLOC_W" = "-" ] && [ "$CDP_AVAIL_W" != "-" ] && SCREEN_WRITE "Avail: $CDP_AVAIL_W"
+SCREEN_WRITE "Sw: ${L_NAME:-${C_DEV:-unknown}}"
 ALERT "PoE Survey: $VERDICT (class ${POE_CLASS:--}, alloc ${ALLOC_W})" 12 2>/dev/null
 exit 0

--- a/payloads/library/recon/port_id_beacon/README.md
+++ b/payloads/library/recon/port_id_beacon/README.md
@@ -1,0 +1,75 @@
+# Shark Jack Display - Port ID Beacon
+
+Plug it into an unknown wall jack and read the switch and port straight off the
+OLED, usually in seconds:
+
+```
+Switch: MDF-SW-01
+Port:   Gi1/0/47
+```
+
+It listens passively for a single LLDP or CDP frame, which already names the
+switch and the exact port you are patched into, and **stops the instant it has an
+answer**. That solves most of the "where does this cable actually go?" problem
+without dragging a toner-and-probe kit or a second laptop to the closet.
+
+> **Authorized use only.** Passive: no probes, no scans, no DHCP. Run only on
+> networks you own or are contracted to assess. Minimal output stays on-device
+> under `/root/loot/port_id/`. See the Legal and Disclaimer sections of the
+> repository README.
+
+## How it works
+
+1. Brings `eth0` up with no address (announces nothing) and waits for carrier.
+2. Captures only LLDP (`0x88cc`) and CDP (Cisco multicast) frames.
+3. Polls the capture every couple of seconds and decodes the **switch name** and
+   **port ID**, preferring LLDP and falling back to CDP.
+4. Breaks the moment it has a result and shows it; writes a one-page summary.
+
+Because it returns as soon as a frame arrives, it is typically near-instant. The
+`WAIT_SECS` cap only matters on a switch that beacons slowly (CDP defaults to 60s)
+or not at all.
+
+## Output
+
+On screen: `Switch:` and `Port:` (or `No LLDP/CDP heard` if the wait elapses).
+
+In loot, `/root/loot/port_id/<UTC-timestamp>_<pid>/`:
+
+```
+summary.txt    <- switch, port, source (LLDP/CDP), port description, mgmt IP
+lldp.txt / cdp.txt   <- full neighbor decode
+capture.pcap   <- the frames it caught
+```
+
+The summary carries a little more than the screen (port description, switch
+platform, management IP) for when you want it.
+
+## Configuration (top of [`payload.txt`](payload.txt))
+
+| Knob | Default | Notes |
+|------|---------|-------|
+| `WAIT_SECS` | `75` | worst-case wait. LLDP beacons ~30s, CDP ~60s, so 75s guarantees a cycle. It is a cap: the payload breaks early on the first frame |
+| `POLL` | `2` | how often to check the capture for a result |
+| `LOOT_BASE` | `/root/loot/port_id` | where loot lands |
+
+## Requirements
+
+- **`tcpdump`** (not on stock firmware): `opkg update && opkg install tcpdump`.
+
+## LED / screen cues
+
+`SETUP` -> `SPECIAL` (listening, spinner) -> `FINISH` with the switch/port, or red
+`FAIL` if no LLDP/CDP was heard. The result is also pushed as an `ALERT` so it
+stays on screen.
+
+## Notes
+
+- **No result is a real answer too.** If the switch has LLDP/CDP disabled, or the
+  jack lands on an unmanaged switch or a dumb injector, there is nothing to hear
+  and it reports `No LLDP/CDP heard`. That itself tells you the upstream is not a
+  managed switch advertising its identity.
+- Works on 802.1X / NAC ports: it never requests an IP.
+- For a full drop work-up (link, DHCP, VLAN, internet, mispatch detection) use the
+  `jack_survey` payload instead; this one is the quick "just tell me the port"
+  beacon.

--- a/payloads/library/recon/port_id_beacon/README.md
+++ b/payloads/library/recon/port_id_beacon/README.md
@@ -15,8 +15,7 @@ without dragging a toner-and-probe kit or a second laptop to the closet.
 
 > **Authorized use only.** Passive: no probes, no scans, no DHCP. Run only on
 > networks you own or are contracted to assess. Minimal output stays on-device
-> under `/root/loot/port_id/`. See the Legal and Disclaimer sections of the
-> repository README.
+> under `/root/loot/port_id/`.
 
 ## How it works
 

--- a/payloads/library/recon/port_id_beacon/payload.txt
+++ b/payloads/library/recon/port_id_beacon/payload.txt
@@ -1,0 +1,144 @@
+#!/bin/bash
+# ============================================================================
+#  Title:       Port ID Beacon (Shark Jack Display)
+#  Author:      Brent Mills
+#  Target:      An unknown authorized wall jack you need to trace.
+#  Category:    recon (passive) / cable tracing
+#  Version:     1.0
+# ----------------------------------------------------------------------------
+#  WHAT IT DOES
+#    Plug into an unknown wall jack and read the switch and port off the OLED in
+#    seconds. It listens passively for one LLDP or CDP frame, which already names
+#    the switch and the exact port you are patched into, and shows:
+#        Switch: MDF-SW-01
+#        Port:   Gi1/0/47
+#    It stops the instant it has an answer, so it is usually near-instant; the
+#    wait only runs to its cap on a slow or CDP-only switch. Solves most of the
+#    "where does this cable actually go?" problem without a second device.
+#
+#  AUTHORIZATION
+#    Passive only: no probes, no scans, no DHCP. Run on networks you own or are
+#    contracted to assess. Minimal loot stays on-device in /root/loot.
+#
+#  REQUIRES tcpdump:  opkg update && opkg install tcpdump
+# ============================================================================
+
+# ------------------------------- CONFIG -------------------------------------
+WAIT_SECS=75                    # worst-case wait. LLDP beacons ~30s, CDP ~60s,
+                                # so 75s guarantees a cycle. It breaks early the
+                                # moment a frame is decoded, so this is a cap.
+POLL=2                          # how often to check the capture for a result
+LOOT_BASE="/root/loot/port_id"
+# ----------------------------------------------------------------------------
+
+# ============================ helpers =======================================
+say()  { SCREEN_WRITE "$*" 2>/dev/null; }
+glow() { LED "$@" 2>/dev/null; }
+spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
+spin_down() { STOP_SPINNER 2>/dev/null; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+lldp_field() {
+  awk -v lbl="$2" '
+    index($0,lbl) {
+      rest=substr($0,index($0,lbl)); val=""
+      if (match(rest,/: /)) val=substr(rest,RSTART+2)
+      if (val ~ /^[ \t]*$/) getline val
+      gsub(/^[ \t]+|[ \t]+$/,"",val); sub(/^Subtype[^:]*: /,"",val); print val; exit
+    }' "$1" 2>/dev/null
+}
+
+decode() {  # decode the current pcap into SWITCH/PORT (+ loot fields); sets globals
+  tcpdump -nn -v -r "$PCAP" 'ether proto 0x88cc' 2>/dev/null > "$RUN/lldp.txt"
+  tcpdump -nn -v -r "$PCAP" 'ether host 01:00:0c:cc:cc:cc' 2>/dev/null > "$RUN/cdp.txt"
+  L_NAME=$(lldp_field "$RUN/lldp.txt" 'System Name TLV')
+  L_PORT=$(lldp_field "$RUN/lldp.txt" 'Port ID TLV')
+  L_DESC=$(lldp_field "$RUN/lldp.txt" 'Port Description TLV')
+  L_MGMT=$(grep -i 'Management Address' "$RUN/lldp.txt" 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+  C_DEV=$(grep -i 'Device-ID' "$RUN/cdp.txt" 2>/dev/null | head -1 | sed "s/.*: '//; s/'.*//")
+  C_PORT=$(grep -i 'Port-ID'  "$RUN/cdp.txt" 2>/dev/null | head -1 | sed "s/.*: '//; s/'.*//")
+  C_PLAT=$(grep -i 'Platform' "$RUN/cdp.txt" 2>/dev/null | head -1 | sed "s/.*: '//; s/'.*//")
+  SWITCH="${L_NAME:-$C_DEV}"
+  PORT="${L_PORT:-$C_PORT}"
+  SRC="LLDP"; [ -z "$L_NAME" ] && [ -z "$L_PORT" ] && [ -n "$C_DEV$C_PORT" ] && SRC="CDP"
+}
+# ============================================================================
+
+
+# ------------------------------ PHASE: SETUP --------------------------------
+glow SETUP
+CLEAR_SCREEN 2>/dev/null
+say "Port ID Beacon"
+
+if ! have tcpdump; then
+  glow FAIL
+  say "tcpdump missing"
+  ALERT "Install tcpdump: opkg install tcpdump" 8 2>/dev/null
+  exit 1
+fi
+
+RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
+mkdir -p "$RUN"
+REPORT="$RUN/summary.txt"
+PCAP="$RUN/capture.pcap"
+
+# Link up, no IP: passive only.
+ip link set eth0 up 2>/dev/null
+WAIT_FOR_LINK 2>/dev/null
+
+
+# ---------------------------- PHASE: LISTEN ---------------------------------
+glow SPECIAL
+say "Listening for LLDP/CDP"
+spin_up "Waiting for a frame"
+
+# Capture only LLDP (0x88cc) and CDP (Cisco multicast); poll and stop on first hit.
+tcpdump -i eth0 -s 0 -w "$PCAP" 'ether proto 0x88cc or ether host 01:00:0c:cc:cc:cc' 2>/dev/null &
+TPID=$!
+
+SWITCH=""; PORT=""; SRC=""
+elapsed=0
+while [ "$elapsed" -lt "$WAIT_SECS" ]; do
+  sleep "$POLL"; elapsed=$((elapsed + POLL))
+  [ -s "$PCAP" ] || continue
+  decode
+  [ -n "$SWITCH" ] || [ -n "$PORT" ] && break
+done
+
+kill "$TPID" 2>/dev/null; wait "$TPID" 2>/dev/null
+[ -s "$PCAP" ] && decode      # final decode in case a frame landed on the last tick
+spin_down
+
+
+# --------------------------- PHASE: RESULT ----------------------------------
+{
+  echo "=========================================================="
+  echo " SHARK JACK DISPLAY - PORT ID BEACON"
+  echo "=========================================================="
+  echo " Run time : $(date -u '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null)"
+  echo " Waited   : up to ${WAIT_SECS}s (stopped at ${elapsed}s)"
+  echo ""
+  echo " Switch   : ${SWITCH:-not advertised}"
+  echo " Port     : ${PORT:-not advertised}"
+  echo " Source   : ${SRC:--}"
+  echo " Port desc: ${L_DESC:--}"
+  echo " Platform : ${C_PLAT:--}"
+  echo " Mgmt IP  : ${L_MGMT:--}"
+  echo ""
+  echo " Raw decode: lldp.txt / cdp.txt   Capture: capture.pcap"
+  echo "=========================================================="
+} > "$REPORT"
+
+CLEAR_SCREEN 2>/dev/null
+if [ -n "$SWITCH" ] || [ -n "$PORT" ]; then
+  glow FINISH
+  say "Switch: ${SWITCH:-unknown}"
+  say "Port: ${PORT:-unknown}"
+  ALERT "Port ID: ${SWITCH:-?} ${PORT:-?}" 15 2>/dev/null
+else
+  glow FAIL
+  say "No LLDP/CDP heard"
+  say "in ${WAIT_SECS}s"
+  ALERT "No LLDP/CDP: unmanaged switch, or LLDP/CDP disabled" 12 2>/dev/null
+fi
+exit 0

--- a/payloads/library/recon/port_id_beacon/payload.txt
+++ b/payloads/library/recon/port_id_beacon/payload.txt
@@ -5,6 +5,7 @@
 #  Target:      An unknown authorized wall jack you need to trace.
 #  Category:    recon (passive) / cable tracing
 #  Version:     1.0
+#  Firmware:    Tested on Shark Jack Display 1.0.1
 # ----------------------------------------------------------------------------
 #  WHAT IT DOES
 #    Plug into an unknown wall jack and read the switch and port off the OLED in

--- a/payloads/library/recon/port_id_beacon/payload.txt
+++ b/payloads/library/recon/port_id_beacon/payload.txt
@@ -34,7 +34,6 @@ LOOT_BASE="/root/loot/port_id"
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-glow() { LED "$@" 2>/dev/null; }
 spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
@@ -67,12 +66,12 @@ decode() {  # decode the current pcap into SWITCH/PORT (+ loot fields); sets glo
 
 
 # ------------------------------ PHASE: SETUP --------------------------------
-glow SETUP
+LED SETUP
 CLEAR_SCREEN 2>/dev/null
 say "Port ID Beacon"
 
 if ! have tcpdump; then
-  glow FAIL
+  LED FAIL
   say "tcpdump missing"
   ALERT "Install tcpdump: opkg install tcpdump" 8 2>/dev/null
   exit 1
@@ -89,7 +88,7 @@ WAIT_FOR_LINK 2>/dev/null
 
 
 # ---------------------------- PHASE: LISTEN ---------------------------------
-glow SPECIAL
+LED SPECIAL
 say "Listening for LLDP/CDP"
 spin_up "Waiting for a frame"
 
@@ -132,12 +131,12 @@ spin_down
 
 CLEAR_SCREEN 2>/dev/null
 if [ -n "$SWITCH" ] || [ -n "$PORT" ]; then
-  glow FINISH
+  LED FINISH
   say "Switch: ${SWITCH:-unknown}"
   say "Port: ${PORT:-unknown}"
   ALERT "Port ID: ${SWITCH:-?} ${PORT:-?}" 15 2>/dev/null
 else
-  glow FAIL
+  LED FAIL
   say "No LLDP/CDP heard"
   say "in ${WAIT_SECS}s"
   ALERT "No LLDP/CDP: unmanaged switch, or LLDP/CDP disabled" 12 2>/dev/null

--- a/payloads/library/recon/port_id_beacon/payload.txt
+++ b/payloads/library/recon/port_id_beacon/payload.txt
@@ -33,7 +33,6 @@ LOOT_BASE="/root/loot/port_id"
 # ----------------------------------------------------------------------------
 
 # ============================ helpers =======================================
-say()  { SCREEN_WRITE "$*" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
 lldp_field() {
@@ -66,11 +65,11 @@ decode() {  # decode the current pcap into SWITCH/PORT (+ loot fields); sets glo
 # ------------------------------ PHASE: SETUP --------------------------------
 LED SETUP
 CLEAR_SCREEN 2>/dev/null
-say "Port ID Beacon"
+SCREEN_WRITE "Port ID Beacon"
 
 if ! have tcpdump; then
   LED FAIL
-  say "tcpdump missing"
+  SCREEN_WRITE "tcpdump missing"
   ALERT "Install tcpdump: opkg install tcpdump" 8 2>/dev/null
   exit 1
 fi
@@ -87,7 +86,7 @@ WAIT_FOR_LINK 2>/dev/null
 
 # ---------------------------- PHASE: LISTEN ---------------------------------
 LED SPECIAL
-say "Listening for LLDP/CDP"
+SCREEN_WRITE "Listening for LLDP/CDP"
 CREATE_SPINNER "Waiting for a frame"
 
 # Capture only LLDP (0x88cc) and CDP (Cisco multicast); poll and stop on first hit.
@@ -130,13 +129,13 @@ STOP_SPINNER
 CLEAR_SCREEN 2>/dev/null
 if [ -n "$SWITCH" ] || [ -n "$PORT" ]; then
   LED FINISH
-  say "Switch: ${SWITCH:-unknown}"
-  say "Port: ${PORT:-unknown}"
+  SCREEN_WRITE "Switch: ${SWITCH:-unknown}"
+  SCREEN_WRITE "Port: ${PORT:-unknown}"
   ALERT "Port ID: ${SWITCH:-?} ${PORT:-?}" 15 2>/dev/null
 else
   LED FAIL
-  say "No LLDP/CDP heard"
-  say "in ${WAIT_SECS}s"
+  SCREEN_WRITE "No LLDP/CDP heard"
+  SCREEN_WRITE "in ${WAIT_SECS}s"
   ALERT "No LLDP/CDP: unmanaged switch, or LLDP/CDP disabled" 12 2>/dev/null
 fi
 exit 0

--- a/payloads/library/recon/port_id_beacon/payload.txt
+++ b/payloads/library/recon/port_id_beacon/payload.txt
@@ -34,7 +34,6 @@ LOOT_BASE="/root/loot/port_id"
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
 lldp_field() {
@@ -106,7 +105,7 @@ done
 
 kill "$TPID" 2>/dev/null; wait "$TPID" 2>/dev/null
 [ -s "$PCAP" ] && decode      # final decode in case a frame landed on the last tick
-spin_down
+STOP_SPINNER
 
 
 # --------------------------- PHASE: RESULT ----------------------------------

--- a/payloads/library/recon/port_id_beacon/payload.txt
+++ b/payloads/library/recon/port_id_beacon/payload.txt
@@ -34,7 +34,6 @@ LOOT_BASE="/root/loot/port_id"
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
@@ -90,7 +89,7 @@ WAIT_FOR_LINK 2>/dev/null
 # ---------------------------- PHASE: LISTEN ---------------------------------
 LED SPECIAL
 say "Listening for LLDP/CDP"
-spin_up "Waiting for a frame"
+CREATE_SPINNER "Waiting for a frame"
 
 # Capture only LLDP (0x88cc) and CDP (Cisco multicast); poll and stop on first hit.
 tcpdump -i eth0 -s 0 -w "$PCAP" 'ether proto 0x88cc or ether host 01:00:0c:cc:cc:cc' 2>/dev/null &

--- a/payloads/library/recon/posture_quickhits/README.md
+++ b/payloads/library/recon/posture_quickhits/README.md
@@ -1,0 +1,62 @@
+# Shark Jack Display - Security Posture Quick-Hits
+
+Sweeps the live hosts for the findings that actually drive a remediation
+proposal and writes them as a severity-tagged list. Targeted scripts run only
+against hosts with the relevant port open, so it stays reasonably quick.
+
+> **Authorized use only.** Run only on networks you own or are contracted to
+> assess, within the agreed scope and time window. Default-community SNMP testing
+> and SMB enumeration are standard assessment steps; stay within authorized
+> scope. Nothing is exfiltrated: all output stays on-device under
+> `/root/loot/posture/` until you retrieve it. See the Legal and Disclaimer
+> sections of the repository README.
+
+## What it checks
+
+| Finding | Severity |
+|---------|----------|
+| SMBv1 still enabled | HIGH (ransomware-relevant) |
+| SMB signing not required | HIGH |
+| SNMP default community (`public`/`private`) responds | MED |
+| Legacy cleartext: telnet (23), FTP (21), r-services (512/513/514) | MED / LOW |
+| Exposed RDP (3389) / VNC (5900) | MED |
+| Legacy TLS (1.0 / SSLv3), weak cipher grades (C/D/F) | LOW |
+
+## Output (loot)
+
+`/root/loot/posture/<UTC-timestamp>_<pid>/`:
+
+```
+summary.txt   <- severity-tagged findings + affected hosts (read this first)
+smb.txt snmp.txt legacy.txt tls.txt   <- per-check raw nmap output
+discovery.gnmap
+```
+
+## Configuration (top of [`payload.txt`](payload.txt))
+
+| Knob | Default | Notes |
+|------|---------|-------|
+| `DHCP_WAIT_SECS` | `30` | wait for a lease before failing |
+| `NMAP_TIMING` | `-T4` | `-T3` quieter, `-T5` aggressive |
+| `HOST_TIMEOUT` | `60s` | per-host budget so one slow host cannot stall the run |
+| `SNMP_COMMUNITIES` | `"public private"` | default strings to test on UDP/161 |
+| `SCAN_TAGGED_VLANS` | `1` | **active VLAN-hopping** on a trunk; set `0` for client sites unless explicitly authorized |
+| `VLAN_PROBE_IDS` | `""` | fallback VIDs if none are sniffed |
+| `PASSIVE_VLAN_SECS` | `12` | passive 802.1Q listen window (needs `tcpdump`) |
+| `LOOT_BASE` | `/root/loot/posture` | where loot lands |
+
+## Requirements
+
+- **`nmap`** (ships on the device). **`tcpdump`** optional, only for passive
+  802.1Q tag sniffing on a trunk.
+
+## LED / screen cues
+
+`SETUP` -> `SPECIAL` (lease) -> `STAGE1` scan -> `CLEANUP` (scoring findings) ->
+`FINISH`. Red `FAIL` means no DHCP lease or no live hosts.
+
+## Notes
+
+- It scans every live host, so on a busy /24 run it on USB-C power.
+- `SCAN_TAGGED_VLANS=1` is active VLAN-hopping: noisy and intrusive. It no-ops on
+  a plain access port. Leave it `0` unless the engagement authorizes it.

--- a/payloads/library/recon/posture_quickhits/README.md
+++ b/payloads/library/recon/posture_quickhits/README.md
@@ -8,8 +8,7 @@ against hosts with the relevant port open, so it stays reasonably quick.
 > assess, within the agreed scope and time window. Default-community SNMP testing
 > and SMB enumeration are standard assessment steps; stay within authorized
 > scope. Nothing is exfiltrated: all output stays on-device under
-> `/root/loot/posture/` until you retrieve it. See the Legal and Disclaimer
-> sections of the repository README.
+> `/root/loot/posture/` until you retrieve it.
 
 ## What it checks
 

--- a/payloads/library/recon/posture_quickhits/payload.txt
+++ b/payloads/library/recon/posture_quickhits/payload.txt
@@ -1,0 +1,233 @@
+#!/bin/bash
+# ============================================================================
+#  Title:       Security Posture Quick-Hits (Shark Jack Display)
+#  Author:      Brent Mills
+#  Target:      An authorized wired drop, scoping a new environment.
+#  Category:    recon / assessment
+#  Version:     1.0
+# ----------------------------------------------------------------------------
+#  WHAT IT DOES
+#    Sweeps the live hosts for the findings that actually drive a remediation
+#    proposal, and writes them as a severity-tagged list:
+#      - SMBv1 still enabled           (HIGH, ransomware-relevant)
+#      - SMB signing not required      (HIGH)
+#      - SNMP default community 'public'(MED, leaks gear config)
+#      - Legacy cleartext: telnet/ftp/r-services (MED/LOW)
+#      - Exposed RDP / VNC             (MED)
+#      - Legacy TLS (1.0/SSLv3), weak cipher grades (LOW)
+#    Targeted scripts run only against hosts with the relevant port open, so it
+#    stays reasonably quick.
+#
+#  AUTHORIZATION
+#    Active, authenticated-to-nothing assessment scans against the in-scope
+#    network only. Default SNMP community testing and SMB enumeration are
+#    standard assessment steps; stay within authorized scope. Output stays
+#    on-device in /root/loot until you pull it.
+# ============================================================================
+
+# ------------------------------- CONFIG -------------------------------------
+DHCP_WAIT_SECS=30
+NMAP_TIMING="-T4"
+HOST_TIMEOUT="60s"
+SNMP_COMMUNITIES="public private"   # default strings to test (UDP/161)
+LOOT_BASE="/root/loot/posture"
+# VLAN-aware scanning: also tag onto and scan tagged VLANs seen on a trunk.
+SCAN_TAGGED_VLANS=0            # 1 = discover+scan tagged VLANs too. ACTIVE VLAN-
+                              #     hopping; set 0 for client sites unless it is
+                              #     authorized. No-op on a plain access port.
+VLAN_PROBE_IDS=""             # fallback VIDs if none are sniffed, e.g. "2 3 10"
+PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
+# ----------------------------------------------------------------------------
+
+# ============================ helpers =======================================
+say()  { SCREEN_WRITE "$*" 2>/dev/null; }
+glow() { LED "$@" 2>/dev/null; }
+spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
+spin_down() { STOP_SPINNER 2>/dev/null; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Hosts whose nmap -oN block contains a line matching <regex>. Space-separated.
+hosts_matching() {                              # hosts_matching <oN_file> <regex>
+  awk -v re="$2" '
+    /^Nmap scan report for /{h=$0; sub(/^Nmap scan report for /,"",h); next}
+    $0 ~ re { if (h!="" && !s[h]) { print h; s[h]=1 } }
+  ' "$1" 2>/dev/null | tr '\n' ' '
+}
+# Emit a finding line only when there are affected hosts; count it.
+NFIND=0
+finding() {                                     # finding <severity> <text> <hosts>
+  [ -z "$3" ] && return
+  NFIND=$((NFIND+1))
+  printf " [%s] %s\n        %s\n" "$1" "$2" "$3" >> "$REPORT"
+}
+# ============================================================================
+
+
+# ---- VLAN-aware scanning (shared block; keep identical across payloads) -----
+ip_to_int() { local IFS=.; set -- $1; echo $(( ($1<<24)|($2<<16)|($3<<8)|$4 )); }
+int_to_ip() { local i=$1; echo "$(((i>>24)&255)).$(((i>>16)&255)).$(((i>>8)&255)).$((i&255))"; }
+mask_for()  { local p=$1; echo $(( (0xFFFFFFFF << (32-p)) & 0xFFFFFFFF )); }
+network_cidr() { local ip=$1 p=$2 m; m=$(mask_for "$p"); echo "$(int_to_ip $(( $(ip_to_int "$ip") & m )))/$p"; }
+VLAN_SUBNETS=""                                 # "vid:net/prefix ..." for labeling
+vlan_for_ip() {
+  local ip=$1 ipi entry vid cidr net p m; ipi=$(ip_to_int "$ip")
+  for entry in $VLAN_SUBNETS; do
+    vid=${entry%%:*}; cidr=${entry#*:}; net=${cidr%/*}; p=${cidr#*/}; m=$(mask_for "$p")
+    [ $(( ipi & m )) -eq $(( $(ip_to_int "$net") & m )) ] && { echo "vlan$vid"; return; }
+  done
+  echo "access"
+}
+vlan_candidates() {                             # VIDs to scan: sniffed 802.1Q tags, else fallback
+  local tags=""
+  have tcpdump && tags=$(timeout "${PASSIVE_VLAN_SECS}s" tcpdump -e -nn -i eth0 -c 300 vlan 2>/dev/null \
+    | grep -oE 'vlan [0-9]+' | awk '{print $2}' | sort -un | tr '\n' ' ')
+  [ -z "$tags" ] && tags="$VLAN_PROBE_IDS"
+  echo "$tags"
+}
+# Run <cb> over the native VLAN, then (if enabled) each tagged VLAN: bring up
+# eth0.<vid>, DHCP, derive its CIDR, call "<cb> <iface> <cidr> <label>", tear down.
+run_over_vlans() {                              # run_over_vlans <cb> <native_network_cidr>
+  local cb=$1 ncidr=$2 vid vline vcidr vids
+  "$cb" eth0 "$ncidr" access
+  [ "$SCAN_TAGGED_VLANS" = "1" ] || return
+  have ip || return; have udhcpc || return
+  lsmod 2>/dev/null | grep -q 8021q || modprobe 8021q 2>/dev/null
+  vids=$(vlan_candidates)
+  for vid in $vids; do
+    ip link add link eth0 name "eth0.$vid" type vlan id "$vid" 2>/dev/null
+    ip link show "eth0.$vid" >/dev/null 2>&1 || { say "VLAN $vid: no 802.1Q"; continue; }
+    ip link set "eth0.$vid" up 2>/dev/null
+    udhcpc -i "eth0.$vid" -n -q -t 4 -T 3 >/dev/null 2>&1
+    vline=$(ip addr show "eth0.$vid" 2>/dev/null | grep -oE 'inet [0-9.]+/[0-9]+' | head -1 | awk '{print $2}')
+    if [ -n "$vline" ]; then
+      vcidr=$(network_cidr "${vline%/*}" "${vline#*/}")
+      if [ "$vcidr" != "$ncidr" ]; then
+        VLAN_SUBNETS="$VLAN_SUBNETS ${vid}:${vcidr}"
+        "$cb" "eth0.$vid" "$vcidr" "vlan$vid"
+      fi
+    fi
+    ip link set "eth0.$vid" down 2>/dev/null
+    ip link del "eth0.$vid" 2>/dev/null
+  done
+}
+# ----------------------------------------------------------------------------
+
+# ------------------------------ PHASE: SETUP --------------------------------
+glow SETUP
+CLEAR_SCREEN 2>/dev/null
+say "Posture quick-hits"
+if ! have nmap; then glow FAIL; say "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
+RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
+mkdir -p "$RUN"; REPORT="$RUN/summary.txt"
+
+
+# --------------------------- PHASE: NETWORK UP ------------------------------
+glow SPECIAL
+say "DHCP lease (eth0)"
+NETMODE DHCP_CLIENT 2>/dev/null
+WAIT_FOR_LINK 2>/dev/null            # framework: block until carrier is up (the race fix)
+# Bounded lease wait: WAIT_FOR_IP blocks forever, so keep our own timeout to fail
+# cleanly on a NAC'd / no-DHCP drop instead of running blind.
+IP=""; PREFIX=""
+for _ in $(seq 1 "$DHCP_WAIT_SECS"); do
+  line=$(ip -o -4 addr show eth0 2>/dev/null | awk '{print $4}')
+  if [ -n "$line" ]; then IP=${line%/*}; PREFIX=${line#*/}; break; fi
+  sleep 1
+done
+if [ -z "$IP" ]; then
+  glow FAIL; say "No lease - 802.1X?"
+  echo "FAILED: no DHCP lease on eth0 (NAC/802.1X, no DHCP, or dead drop)." > "$REPORT"
+  ALERT "No DHCP lease - see loot" 8 2>/dev/null; exit 1
+fi
+say "IP $IP/$PREFIX"
+
+
+# ----------------------- PHASE: DISCOVER + SCAN -----------------------------
+SNMP_ARGS=$(echo "$SNMP_COMMUNITIES" | sed 's/ /,/g')
+# Posture-scan one (iface, cidr): discover, then SMB / SNMP / legacy / TLS.
+# Per-label raw files so the native VLAN and each tagged VLAN accumulate.
+scan_one() {                                    # scan_one <iface> <cidr> <label>
+  local iface=$1 cidr=$2 label=$3 n L
+  nmap -sn $NMAP_TIMING -e "$iface" -oG "$RUN/disc_$label.gnmap" "$cidr" >/dev/null 2>&1
+  awk '/Status: Up/{print $2}' "$RUN/disc_$label.gnmap" 2>/dev/null | sort -u > "$RUN/up_$label.txt"
+  n=$(wc -l < "$RUN/up_$label.txt" 2>/dev/null | tr -d ' '); [ -z "$n" ] && n=0
+  [ "$n" -eq 0 ] && return
+  say "$label: $n hosts"
+  L="$RUN/up_$label.txt"
+  nmap -Pn $NMAP_TIMING --host-timeout "$HOST_TIMEOUT" -e "$iface" -p139,445 \
+    --script smb-protocols,smb2-security-mode,smb-os-discovery -iL "$L" -oN "$RUN/smb_$label.txt" >/dev/null 2>&1
+  nmap -Pn -sU $NMAP_TIMING --host-timeout "$HOST_TIMEOUT" -e "$iface" -p161 \
+    --script snmp-info --script-args "snmpcommunity={$SNMP_ARGS}" -iL "$L" -oN "$RUN/snmp_$label.txt" >/dev/null 2>&1
+  nmap -Pn $NMAP_TIMING --host-timeout "$HOST_TIMEOUT" -e "$iface" -p21,23,512,513,514,3389,5900 \
+    -iL "$L" -oN "$RUN/legacy_$label.txt" >/dev/null 2>&1
+  nmap -Pn $NMAP_TIMING --host-timeout "$HOST_TIMEOUT" -e "$iface" -p443,636,993,995,8443,9443 \
+    --script ssl-cert,ssl-enum-ciphers -iL "$L" -oN "$RUN/tls_$label.txt" >/dev/null 2>&1
+}
+
+glow STAGE1
+say "Scanning (native + tagged VLANs)"
+spin_up "Posture scan"
+NATIVE_CIDR=$(network_cidr "$IP" "$PREFIX")
+run_over_vlans scan_one "$NATIVE_CIDR"
+spin_down
+
+# Merge per-VLAN raw output so the findings logic sees every VLAN.
+cat "$RUN"/smb_*.txt    > "$RUN/smb.txt"    2>/dev/null
+cat "$RUN"/snmp_*.txt   > "$RUN/snmp.txt"   2>/dev/null
+cat "$RUN"/legacy_*.txt > "$RUN/legacy.txt" 2>/dev/null
+cat "$RUN"/tls_*.txt    > "$RUN/tls.txt"    2>/dev/null
+cat "$RUN"/up_*.txt 2>/dev/null | sort -u > "$RUN/up.txt"
+UPCOUNT=$(wc -l < "$RUN/up.txt" 2>/dev/null | tr -d ' '); [ -z "$UPCOUNT" ] && UPCOUNT=0
+say "$UPCOUNT hosts up"
+if [ "$UPCOUNT" -eq 0 ]; then
+  glow FAIL; echo "No live hosts discovered on $IP/$PREFIX (any VLAN)." > "$REPORT"
+  ALERT "No hosts found" 8 2>/dev/null; exit 0
+fi
+
+
+# --------------------------- PHASE: WRITE LOOT ------------------------------
+glow CLEANUP
+say "Scoring findings"
+{
+  echo "=========================================================="
+  echo " SHARK JACK DISPLAY - POSTURE QUICK-HITS"
+  echo "=========================================================="
+  echo " Run time : $(date -u '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null)"
+  echo " From     : $IP/$PREFIX     Hosts scanned: $UPCOUNT"
+  echo " VLANs    : native $(network_cidr "$IP" "$PREFIX")${VLAN_SUBNETS:+ ; tagged}${VLAN_SUBNETS}"
+  echo ""
+  echo "---- FINDINGS (severity / affected hosts) ----------------"
+} > "$REPORT"
+
+finding HIGH "SMBv1 enabled"                  "$(hosts_matching "$RUN/smb.txt" 'SMBv1')"
+finding HIGH "SMB signing not required"       "$(hosts_matching "$RUN/smb.txt" 'not required')"
+finding MED  "SNMP default community responds" "$(hosts_matching "$RUN/snmp.txt" 'snmp-info|snmpEngine|System uptime')"
+finding MED  "Telnet (23) open - cleartext"   "$(hosts_matching "$RUN/legacy.txt" '^23/tcp[ \t]+open')"
+finding LOW  "FTP (21) open - cleartext"      "$(hosts_matching "$RUN/legacy.txt" '^21/tcp[ \t]+open')"
+finding MED  "r-services (512/513/514) open"  "$(hosts_matching "$RUN/legacy.txt" '^(512|513|514)/tcp[ \t]+open')"
+finding MED  "RDP (3389) exposed"             "$(hosts_matching "$RUN/legacy.txt" '^3389/tcp[ \t]+open')"
+finding MED  "VNC (5900) open"                "$(hosts_matching "$RUN/legacy.txt" '^5900/tcp[ \t]+open')"
+finding LOW  "Legacy TLS/SSL (1.0 / SSLv3)"   "$(hosts_matching "$RUN/tls.txt" 'TLSv1\.0|SSLv3|SSLv2')"
+finding LOW  "Weak TLS cipher grade (C/D/F)"  "$(hosts_matching "$RUN/tls.txt" 'least strength: [CDF]')"
+
+if [ "$NFIND" -eq 0 ]; then echo " No quick-hit findings (clean on the checks run)." >> "$REPORT"; fi
+{
+  echo ""
+  echo "---- NOTES -----------------------------------------------"
+  echo " Full per-host output (incl. cert subjects/expiry, SMB OS,"
+  echo " SNMP system info) is in the raw files below."
+  echo ""
+  echo "---- RAW ARTIFACTS ---------------------------------------"
+  echo " smb.txt  snmp.txt  legacy.txt  tls.txt  discovery.gnmap"
+  echo "=========================================================="
+} >> "$REPORT"
+
+
+# ------------------------------ PHASE: DONE ---------------------------------
+glow FINISH
+CLEAR_SCREEN 2>/dev/null
+say "Posture scan done"
+say "Findings: $NFIND"
+say "Hosts: $UPCOUNT"
+ALERT "Posture done: $NFIND finding categories across $UPCOUNT hosts." 12 2>/dev/null
+exit 0

--- a/payloads/library/recon/posture_quickhits/payload.txt
+++ b/payloads/library/recon/posture_quickhits/payload.txt
@@ -42,7 +42,6 @@ PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-glow() { LED "$@" 2>/dev/null; }
 spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
@@ -114,16 +113,16 @@ run_over_vlans() {                              # run_over_vlans <cb> <native_ne
 # ----------------------------------------------------------------------------
 
 # ------------------------------ PHASE: SETUP --------------------------------
-glow SETUP
+LED SETUP
 CLEAR_SCREEN 2>/dev/null
 say "Posture quick-hits"
-if ! have nmap; then glow FAIL; say "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
+if ! have nmap; then LED FAIL; say "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
 RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
 mkdir -p "$RUN"; REPORT="$RUN/summary.txt"
 
 
 # --------------------------- PHASE: NETWORK UP ------------------------------
-glow SPECIAL
+LED SPECIAL
 say "DHCP lease (eth0)"
 NETMODE DHCP_CLIENT 2>/dev/null
 WAIT_FOR_LINK 2>/dev/null            # framework: block until carrier is up (the race fix)
@@ -136,7 +135,7 @@ for _ in $(seq 1 "$DHCP_WAIT_SECS"); do
   sleep 1
 done
 if [ -z "$IP" ]; then
-  glow FAIL; say "No lease - 802.1X?"
+  LED FAIL; say "No lease - 802.1X?"
   echo "FAILED: no DHCP lease on eth0 (NAC/802.1X, no DHCP, or dead drop)." > "$REPORT"
   ALERT "No DHCP lease - see loot" 8 2>/dev/null; exit 1
 fi
@@ -165,7 +164,7 @@ scan_one() {                                    # scan_one <iface> <cidr> <label
     --script ssl-cert,ssl-enum-ciphers -iL "$L" -oN "$RUN/tls_$label.txt" >/dev/null 2>&1
 }
 
-glow STAGE1
+LED STAGE1
 say "Scanning (native + tagged VLANs)"
 spin_up "Posture scan"
 NATIVE_CIDR=$(network_cidr "$IP" "$PREFIX")
@@ -181,13 +180,13 @@ cat "$RUN"/up_*.txt 2>/dev/null | sort -u > "$RUN/up.txt"
 UPCOUNT=$(wc -l < "$RUN/up.txt" 2>/dev/null | tr -d ' '); [ -z "$UPCOUNT" ] && UPCOUNT=0
 say "$UPCOUNT hosts up"
 if [ "$UPCOUNT" -eq 0 ]; then
-  glow FAIL; echo "No live hosts discovered on $IP/$PREFIX (any VLAN)." > "$REPORT"
+  LED FAIL; echo "No live hosts discovered on $IP/$PREFIX (any VLAN)." > "$REPORT"
   ALERT "No hosts found" 8 2>/dev/null; exit 0
 fi
 
 
 # --------------------------- PHASE: WRITE LOOT ------------------------------
-glow CLEANUP
+LED CLEANUP
 say "Scoring findings"
 {
   echo "=========================================================="
@@ -225,7 +224,7 @@ if [ "$NFIND" -eq 0 ]; then echo " No quick-hit findings (clean on the checks ru
 
 
 # ------------------------------ PHASE: DONE ---------------------------------
-glow FINISH
+LED FINISH
 CLEAR_SCREEN 2>/dev/null
 say "Posture scan done"
 say "Findings: $NFIND"

--- a/payloads/library/recon/posture_quickhits/payload.txt
+++ b/payloads/library/recon/posture_quickhits/payload.txt
@@ -5,6 +5,7 @@
 #  Target:      An authorized wired drop, scoping a new environment.
 #  Category:    recon / assessment
 #  Version:     1.0
+#  Firmware:    Tested on Shark Jack Display 1.0.1
 # ----------------------------------------------------------------------------
 #  WHAT IT DOES
 #    Sweeps the live hosts for the findings that actually drive a remediation

--- a/payloads/library/recon/posture_quickhits/payload.txt
+++ b/payloads/library/recon/posture_quickhits/payload.txt
@@ -42,7 +42,6 @@ PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
 # Hosts whose nmap -oN block contains a line matching <regex>. Space-separated.
@@ -168,7 +167,7 @@ say "Scanning (native + tagged VLANs)"
 CREATE_SPINNER "Posture scan"
 NATIVE_CIDR=$(network_cidr "$IP" "$PREFIX")
 run_over_vlans scan_one "$NATIVE_CIDR"
-spin_down
+STOP_SPINNER
 
 # Merge per-VLAN raw output so the findings logic sees every VLAN.
 cat "$RUN"/smb_*.txt    > "$RUN/smb.txt"    2>/dev/null

--- a/payloads/library/recon/posture_quickhits/payload.txt
+++ b/payloads/library/recon/posture_quickhits/payload.txt
@@ -41,7 +41,6 @@ PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
 # ----------------------------------------------------------------------------
 
 # ============================ helpers =======================================
-say()  { SCREEN_WRITE "$*" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
 # Hosts whose nmap -oN block contains a line matching <regex>. Space-separated.
@@ -93,7 +92,7 @@ run_over_vlans() {                              # run_over_vlans <cb> <native_ne
   vids=$(vlan_candidates)
   for vid in $vids; do
     ip link add link eth0 name "eth0.$vid" type vlan id "$vid" 2>/dev/null
-    ip link show "eth0.$vid" >/dev/null 2>&1 || { say "VLAN $vid: no 802.1Q"; continue; }
+    ip link show "eth0.$vid" >/dev/null 2>&1 || { SCREEN_WRITE "VLAN $vid: no 802.1Q"; continue; }
     ip link set "eth0.$vid" up 2>/dev/null
     udhcpc -i "eth0.$vid" -n -q -t 4 -T 3 >/dev/null 2>&1
     vline=$(ip addr show "eth0.$vid" 2>/dev/null | grep -oE 'inet [0-9.]+/[0-9]+' | head -1 | awk '{print $2}')
@@ -113,15 +112,15 @@ run_over_vlans() {                              # run_over_vlans <cb> <native_ne
 # ------------------------------ PHASE: SETUP --------------------------------
 LED SETUP
 CLEAR_SCREEN 2>/dev/null
-say "Posture quick-hits"
-if ! have nmap; then LED FAIL; say "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
+SCREEN_WRITE "Posture quick-hits"
+if ! have nmap; then LED FAIL; SCREEN_WRITE "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
 RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
 mkdir -p "$RUN"; REPORT="$RUN/summary.txt"
 
 
 # --------------------------- PHASE: NETWORK UP ------------------------------
 LED SPECIAL
-say "DHCP lease (eth0)"
+SCREEN_WRITE "DHCP lease (eth0)"
 NETMODE DHCP_CLIENT 2>/dev/null
 WAIT_FOR_LINK 2>/dev/null            # framework: block until carrier is up (the race fix)
 # Bounded lease wait: WAIT_FOR_IP blocks forever, so keep our own timeout to fail
@@ -133,11 +132,11 @@ for _ in $(seq 1 "$DHCP_WAIT_SECS"); do
   sleep 1
 done
 if [ -z "$IP" ]; then
-  LED FAIL; say "No lease - 802.1X?"
+  LED FAIL; SCREEN_WRITE "No lease - 802.1X?"
   echo "FAILED: no DHCP lease on eth0 (NAC/802.1X, no DHCP, or dead drop)." > "$REPORT"
   ALERT "No DHCP lease - see loot" 8 2>/dev/null; exit 1
 fi
-say "IP $IP/$PREFIX"
+SCREEN_WRITE "IP $IP/$PREFIX"
 
 
 # ----------------------- PHASE: DISCOVER + SCAN -----------------------------
@@ -150,7 +149,7 @@ scan_one() {                                    # scan_one <iface> <cidr> <label
   awk '/Status: Up/{print $2}' "$RUN/disc_$label.gnmap" 2>/dev/null | sort -u > "$RUN/up_$label.txt"
   n=$(wc -l < "$RUN/up_$label.txt" 2>/dev/null | tr -d ' '); [ -z "$n" ] && n=0
   [ "$n" -eq 0 ] && return
-  say "$label: $n hosts"
+  SCREEN_WRITE "$label: $n hosts"
   L="$RUN/up_$label.txt"
   nmap -Pn $NMAP_TIMING --host-timeout "$HOST_TIMEOUT" -e "$iface" -p139,445 \
     --script smb-protocols,smb2-security-mode,smb-os-discovery -iL "$L" -oN "$RUN/smb_$label.txt" >/dev/null 2>&1
@@ -163,7 +162,7 @@ scan_one() {                                    # scan_one <iface> <cidr> <label
 }
 
 LED STAGE1
-say "Scanning (native + tagged VLANs)"
+SCREEN_WRITE "Scanning (native + tagged VLANs)"
 CREATE_SPINNER "Posture scan"
 NATIVE_CIDR=$(network_cidr "$IP" "$PREFIX")
 run_over_vlans scan_one "$NATIVE_CIDR"
@@ -176,7 +175,7 @@ cat "$RUN"/legacy_*.txt > "$RUN/legacy.txt" 2>/dev/null
 cat "$RUN"/tls_*.txt    > "$RUN/tls.txt"    2>/dev/null
 cat "$RUN"/up_*.txt 2>/dev/null | sort -u > "$RUN/up.txt"
 UPCOUNT=$(wc -l < "$RUN/up.txt" 2>/dev/null | tr -d ' '); [ -z "$UPCOUNT" ] && UPCOUNT=0
-say "$UPCOUNT hosts up"
+SCREEN_WRITE "$UPCOUNT hosts up"
 if [ "$UPCOUNT" -eq 0 ]; then
   LED FAIL; echo "No live hosts discovered on $IP/$PREFIX (any VLAN)." > "$REPORT"
   ALERT "No hosts found" 8 2>/dev/null; exit 0
@@ -185,7 +184,7 @@ fi
 
 # --------------------------- PHASE: WRITE LOOT ------------------------------
 LED CLEANUP
-say "Scoring findings"
+SCREEN_WRITE "Scoring findings"
 {
   echo "=========================================================="
   echo " SHARK JACK DISPLAY - POSTURE QUICK-HITS"
@@ -224,8 +223,8 @@ if [ "$NFIND" -eq 0 ]; then echo " No quick-hit findings (clean on the checks ru
 # ------------------------------ PHASE: DONE ---------------------------------
 LED FINISH
 CLEAR_SCREEN 2>/dev/null
-say "Posture scan done"
-say "Findings: $NFIND"
-say "Hosts: $UPCOUNT"
+SCREEN_WRITE "Posture scan done"
+SCREEN_WRITE "Findings: $NFIND"
+SCREEN_WRITE "Hosts: $UPCOUNT"
 ALERT "Posture done: $NFIND finding categories across $UPCOUNT hosts." 12 2>/dev/null
 exit 0

--- a/payloads/library/recon/posture_quickhits/payload.txt
+++ b/payloads/library/recon/posture_quickhits/payload.txt
@@ -32,7 +32,7 @@ HOST_TIMEOUT="60s"
 SNMP_COMMUNITIES="public private"   # default strings to test (UDP/161)
 LOOT_BASE="/root/loot/posture"
 # VLAN-aware scanning: also tag onto and scan tagged VLANs seen on a trunk.
-SCAN_TAGGED_VLANS=0            # 1 = discover+scan tagged VLANs too. ACTIVE VLAN-
+SCAN_TAGGED_VLANS=0           # 1 = discover+scan tagged VLANs too. ACTIVE VLAN-
                               #     hopping; set 0 for client sites unless it is
                               #     authorized. No-op on a plain access port.
 VLAN_PROBE_IDS=""             # fallback VIDs if none are sniffed, e.g. "2 3 10"

--- a/payloads/library/recon/posture_quickhits/payload.txt
+++ b/payloads/library/recon/posture_quickhits/payload.txt
@@ -42,7 +42,6 @@ PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
@@ -166,7 +165,7 @@ scan_one() {                                    # scan_one <iface> <cidr> <label
 
 LED STAGE1
 say "Scanning (native + tagged VLANs)"
-spin_up "Posture scan"
+CREATE_SPINNER "Posture scan"
 NATIVE_CIDR=$(network_cidr "$IP" "$PREFIX")
 run_over_vlans scan_one "$NATIVE_CIDR"
 spin_down

--- a/payloads/library/recon/risky_devices/README.md
+++ b/payloads/library/recon/risky_devices/README.md
@@ -1,0 +1,68 @@
+# Shark Jack Display - Rogue / Risky Device Detector
+
+Finds the devices nobody remembers plugging in and the ones that do not belong,
+then writes a leadership-ready table:
+
+```
+Device | Manufacturer | Version | IP | Open Ports
+```
+
+It classifies every live host by fusing three signals: MAC OUI (with a built-in
+table for Raspberry Pi and Espressif so they are caught even when the device's
+OUI database is stale), an open-port fingerprint, and banners / OS / hostname.
+Risky or unexpected devices are listed first (the leadership headline); the full
+inventory follows.
+
+> **Authorized use only.** Run only on networks you own or are contracted to
+> assess, within the agreed scope and time window. Nothing is exfiltrated: all
+> output stays on-device under `/root/loot/risky/` until you retrieve it. See the
+> Legal and Disclaimer sections of the repository README.
+
+## What it catches
+
+Raspberry Pi / SBCs, consumer Wi-Fi routers and APs, printers / MFPs, IP cameras
+and NVRs, DIY / IoT boards, and endpoints (laptops/desktops) exposing server,
+database, or container ports they should not.
+
+## Output (loot)
+
+`/root/loot/risky/<UTC-timestamp>_<pid>/`:
+
+```
+summary.txt   <- flagged-for-review table + full inventory (read this first)
+services.txt  <- combined nmap -sV -O output, per-host detail
+snmp.txt       <- SNMP sysDescr (printer/switch firmware)
+disc_*.gnmap services_*.txt   <- per-VLAN raw scans
+```
+
+## Configuration (top of [`payload.txt`](payload.txt))
+
+| Knob | Default | Notes |
+|------|---------|-------|
+| `DHCP_WAIT_SECS` | `30` | wait for a lease before failing |
+| `NMAP_TIMING` | `-T4` | `-T3` quieter, `-T5` aggressive |
+| `HOST_TIMEOUT` | `120s` | per-host budget |
+| `OS_DETECT` | `1` | `nmap -O` (helps tell a server from a laptop) |
+| `SNMP_LOOKUP` | `1` | pull SNMP sysDescr (printer/switch firmware) |
+| `PORTSET` | (signal ports) | short classification-signal port list |
+| `SCAN_TAGGED_VLANS` | `1` | **active VLAN-hopping** on a trunk; set `0` for client sites unless explicitly authorized |
+| `VLAN_PROBE_IDS` | `""` | fallback VIDs if none are sniffed |
+| `PASSIVE_VLAN_SECS` | `12` | passive 802.1Q listen window (needs `tcpdump`) |
+| `LOOT_BASE` | `/root/loot/risky` | where loot lands |
+
+## Requirements
+
+- **`nmap`** (ships on the device). **`tcpdump`** optional, only for passive
+  802.1Q tag sniffing on a trunk.
+
+## LED / screen cues
+
+`SETUP` -> `SPECIAL` (lease) -> `STAGE1` scan -> `STAGE4` classify -> `CLEANUP`
+(writing loot) -> `FINISH`. Red `FAIL` means no DHCP lease or no live hosts.
+
+## Notes
+
+- `SCAN_TAGGED_VLANS=1` is active VLAN-hopping: noisy and intrusive. It no-ops on
+  a plain access port. Leave it `0` unless the engagement authorizes it.
+- Vendor "Unknown" in output is usually a stale `nmap-mac-prefixes` table, not a
+  real gap.

--- a/payloads/library/recon/risky_devices/README.md
+++ b/payloads/library/recon/risky_devices/README.md
@@ -15,8 +15,7 @@ inventory follows.
 
 > **Authorized use only.** Run only on networks you own or are contracted to
 > assess, within the agreed scope and time window. Nothing is exfiltrated: all
-> output stays on-device under `/root/loot/risky/` until you retrieve it. See the
-> Legal and Disclaimer sections of the repository README.
+> output stays on-device under `/root/loot/risky/` until you retrieve it.
 
 ## What it catches
 

--- a/payloads/library/recon/risky_devices/payload.txt
+++ b/payloads/library/recon/risky_devices/payload.txt
@@ -1,0 +1,354 @@
+#!/bin/bash
+# ============================================================================
+#  Title:       Rogue / Risky Device Detector (Shark Jack Display)
+#  Author:      Brent Mills
+#  Target:      An authorized wired drop, scoping a new environment.
+#  Category:    recon / assessment
+#  Version:     1.0
+# ----------------------------------------------------------------------------
+#  WHAT IT DOES
+#    Finds the devices nobody remembers plugging in and the ones that don't
+#    belong, then writes a leadership-ready table:
+#        Device | Manufacturer | Version | IP | Open Ports
+#    It classifies every live host by fusing three signals:
+#      - MAC OUI (manufacturer) ... incl. a built-in table for Raspberry Pi and
+#                                   Espressif/ESP so they're caught even when the
+#                                   device's nmap OUI database is stale.
+#      - Open-port fingerprint .... 9100->printer, 554->camera, 7547->consumer
+#                                   router, DB/container ports on a desktop OS->
+#                                   "laptop running production workloads".
+#      - Banners / OS / hostname .. raspbian, jetdirect, hikvision, openwrt, etc.
+#    Risky/unexpected devices are listed FIRST (the leadership headline); the
+#    full inventory follows.
+#
+#  CATCHES (the usual suspects)
+#    Raspberry Pi / SBCs, consumer Wi-Fi routers/APs, printers/MFPs, IP cameras,
+#    DIY/IoT boards, and endpoints (laptops/desktops) exposing server, database,
+#    or container ports they shouldn't.
+#
+#  AUTHORIZATION
+#    Active inventory scan against the in-scope network only. Output stays
+#    on-device in /root/loot until you pull it.
+# ============================================================================
+
+# ------------------------------- CONFIG -------------------------------------
+DHCP_WAIT_SECS=30
+NMAP_TIMING="-T4"
+HOST_TIMEOUT="120s"
+OS_DETECT=1                     # 1 = nmap -O (helps tell a server from a laptop)
+SNMP_LOOKUP=1                   # 1 = pull SNMP sysDescr (printer/switch firmware)
+# Classification-signal ports (kept short for speed + signal).
+PORTSET="21,22,23,25,53,80,110,143,443,445,515,554,623,631,1883,1900,2375,2376,3000,3306,3389,5000,5060,5432,5900,6379,7547,8000,8080,8443,8888,9000,9100,9200,27017"
+LOOT_BASE="/root/loot/risky"
+# VLAN-aware scanning: also tag onto and scan tagged VLANs seen on a trunk.
+SCAN_TAGGED_VLANS=0            # 1 = discover+scan tagged VLANs too. ACTIVE VLAN-
+                              #     hopping; set 0 for client sites unless it is
+                              #     authorized. No-op on a plain access port.
+VLAN_PROBE_IDS=""             # fallback VIDs if none are sniffed, e.g. "2 3 10"
+PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
+# ----------------------------------------------------------------------------
+
+# ============================ helpers =======================================
+say()  { SCREEN_WRITE "$*" 2>/dev/null; }
+glow() { LED "$@" 2>/dev/null; }
+spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
+spin_down() { STOP_SPINNER 2>/dev/null; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Built-in OUI table for the high-signal DIY devices nmap's DB often misses.
+# Sets OUI_TYPE (rpi|esp) and OUI_VENDOR. <mac>
+oui_lookup() {
+  OUI_TYPE=""; OUI_VENDOR=""
+  local o; o=$(echo "$1" | cut -c1-8 | tr 'a-z' 'A-Z')
+  case "$o" in
+    B8:27:EB|DC:A6:32|E4:5F:01|28:CD:C1|D8:3A:DD|2C:CF:67|3A:35:41)
+      OUI_TYPE=rpi; OUI_VENDOR="Raspberry Pi" ;;
+    18:FE:34|5C:CF:7F|24:0A:C4|30:AE:A4|3C:71:BF|60:01:94|68:C6:3A|7C:9E:BD|84:CC:A8|84:F3:EB|A0:20:A6|A4:CF:12|B4:E6:2D|BC:DD:C2|C4:4F:33|CC:50:E3|D8:A0:1D|DC:4F:22|EC:FA:BC|F4:CF:A2)
+      OUI_TYPE=esp; OUI_VENDOR="Espressif (ESP32/8266)" ;;
+  esac
+}
+
+# Classify a host. Sets CT (device type), CR (risk), CRE (reason).
+# Args: vendor os host ports(comma) banner(lowercased)
+classify() {
+  local vendor="$1" os="$2" host="$3" ports="$4" banner="$5"
+  local hay; hay=$(printf '%s %s %s %s' "$vendor" "$os" "$host" "$banner" | tr 'A-Z' 'a-z')
+  local pl=",$ports,"
+  has() { case "$pl" in *,$1,*) return 0;; *) return 1;; esac; }
+  srv_port() { echo "$pl" | grep -qE ',(80|443|3000|5000|8000|8080|8443|8888|9000|3306|5432|6379|27017|1433|9200|2375|2376|5601),'; }
+
+  if [ "$OUI_TYPE" = "rpi" ] || echo "$hay" | grep -qE 'raspberr|raspbian|octopi'; then
+    CT="Raspberry Pi / SBC"; CR="HIGH"; CRE="unmanaged single-board computer"; return; fi
+  if has 9100 || has 515 || has 631 || echo "$hay" | grep -qE 'jetdirect|laserjet|officejet|printer|hewlett|hp inc|canon|epson|brother|lexmark|xerox|ricoh|kyocera|konica'; then
+    CT="Printer / MFP"; CR="MEDIUM"; CRE="often unpatched, default creds, holds scanned docs"; return; fi
+  if has 554 || echo "$hay" | grep -qE 'rtsp|onvif|hikvision|dahua|\baxis\b|reolink|wyze|amcrest|nvr|ip ?cam|goahead|boa/'; then
+    CT="IP camera / NVR"; CR="HIGH"; CRE="cameras are commonly default-cred and exposed"; return; fi
+  if has 7547 || echo "$hay" | grep -qE 'tp-?link|netgear|linksys|d-?link|asus|belkin|tenda|mikrotik|openwrt|dd-?wrt|router|wireless ap'; then
+    CT="Consumer router / AP"; CR="HIGH"; CRE="rogue network gear / unmanaged uplink"; return; fi
+  if [ "$OUI_TYPE" = "esp" ] || has 1883 || echo "$hay" | grep -qE 'espressif|esp32|esp8266|tuya|sonoff|shelly|tasmota|arduino|nodemcu|particle|broadlink|smartthings'; then
+    CT="IoT / DIY embedded"; CR="MEDIUM"; CRE="unmanaged IoT, weak or absent patching"; return; fi
+  if has 5060 || echo "$hay" | grep -qE 'polycom|yealink|grandstream|cisco ip phone|sip/'; then
+    CT="VoIP phone"; CR="INFO"; CRE="expected if they run VoIP"; return; fi
+  # Endpoint (desktop OS / laptop vendor) exposing hosting ports = prod-on-a-laptop.
+  if echo "$hay" | grep -qE 'windows (xp|7|8|10|11)|mac ?os|macos|darwin|apple|macbook|dell|lenovo|thinkpad|optiplex|microsoft|intel corporate' \
+     && ! echo "$hay" | grep -qE 'windows server' && srv_port; then
+    CT="Endpoint running services"; CR="HIGH"; CRE="possible production workload on a user device"; return; fi
+  if echo "$hay" | grep -qE 'windows server|ubuntu|debian|centos|red hat|linux' && srv_port; then
+    CT="Server (verify it's sanctioned)"; CR="REVIEW"; CRE="confirm this host is inventoried and owned"; return; fi
+  if echo "$hay" | grep -qE 'cisco|juniper|aruba|\bhpe\b|ubiquiti|unifi|fortinet|sonicwall|meraki|extreme|brocade'; then
+    CT="Network device"; CR="REVIEW"; CRE="infrastructure - confirm it is sanctioned"; return; fi
+  if echo "$hay" | grep -qE 'windows|desktop-|laptop-'; then CT="Windows workstation"; CR="LOW"; CRE="normal endpoint"; return; fi
+  if echo "$hay" | grep -qE 'apple|mac ?os|macos'; then CT="Apple device"; CR="LOW"; CRE="normal endpoint"; return; fi
+  CT="Unknown"; CR="REVIEW"; CRE="unclassified - verify ownership"
+}
+risk_rank() { case "$1" in HIGH) echo 1;; MEDIUM) echo 2;; REVIEW) echo 3;; LOW) echo 4;; *) echo 5;; esac; }
+# Manufacturer fallback from banner/SNMP keywords when the OUI is unknown.
+guess_vendor() {
+  case "$1" in
+    *raspberr*|*raspbian*) echo "Raspberry Pi";;
+    *espressif*|*esp8266*|*esp32*|*tasmota*) echo "Espressif";;
+    *hewlett*|*laserjet*|*officejet*|*jetdirect*) echo "HP";;
+    *canon*) echo "Canon";; *epson*) echo "Epson";; *brother*) echo "Brother";;
+    *lexmark*) echo "Lexmark";; *xerox*) echo "Xerox";; *ricoh*) echo "Ricoh";; *kyocera*) echo "Kyocera";;
+    *hikvision*) echo "Hikvision";; *dahua*) echo "Dahua";; *amcrest*) echo "Amcrest";; *reolink*) echo "Reolink";;
+    *tp-link*|*tplink*) echo "TP-Link";; *netgear*) echo "Netgear";; *linksys*) echo "Linksys";;
+    *d-link*|*dlink*) echo "D-Link";; *mikrotik*) echo "MikroTik";; *openwrt*) echo "OpenWrt device";;
+    *ubiquiti*|*unifi*) echo "Ubiquiti";; *cisco*) echo "Cisco";; *juniper*) echo "Juniper";;
+    *aruba*) echo "Aruba";; *fortinet*) echo "Fortinet";; *) echo "";;
+  esac
+}
+# ============================================================================
+
+
+# ---- VLAN-aware scanning (shared block; keep identical across payloads) -----
+ip_to_int() { local IFS=.; set -- $1; echo $(( ($1<<24)|($2<<16)|($3<<8)|$4 )); }
+int_to_ip() { local i=$1; echo "$(((i>>24)&255)).$(((i>>16)&255)).$(((i>>8)&255)).$((i&255))"; }
+mask_for()  { local p=$1; echo $(( (0xFFFFFFFF << (32-p)) & 0xFFFFFFFF )); }
+network_cidr() { local ip=$1 p=$2 m; m=$(mask_for "$p"); echo "$(int_to_ip $(( $(ip_to_int "$ip") & m )))/$p"; }
+VLAN_SUBNETS=""                                 # "vid:net/prefix ..." for labeling
+vlan_for_ip() {
+  local ip=$1 ipi entry vid cidr net p m; ipi=$(ip_to_int "$ip")
+  for entry in $VLAN_SUBNETS; do
+    vid=${entry%%:*}; cidr=${entry#*:}; net=${cidr%/*}; p=${cidr#*/}; m=$(mask_for "$p")
+    [ $(( ipi & m )) -eq $(( $(ip_to_int "$net") & m )) ] && { echo "vlan$vid"; return; }
+  done
+  echo "access"
+}
+vlan_candidates() {                             # VIDs to scan: sniffed 802.1Q tags, else fallback
+  local tags=""
+  have tcpdump && tags=$(timeout "${PASSIVE_VLAN_SECS}s" tcpdump -e -nn -i eth0 -c 300 vlan 2>/dev/null \
+    | grep -oE 'vlan [0-9]+' | awk '{print $2}' | sort -un | tr '\n' ' ')
+  [ -z "$tags" ] && tags="$VLAN_PROBE_IDS"
+  echo "$tags"
+}
+# Run <cb> over the native VLAN, then (if enabled) each tagged VLAN: bring up
+# eth0.<vid>, DHCP, derive its CIDR, call "<cb> <iface> <cidr> <label>", tear down.
+run_over_vlans() {                              # run_over_vlans <cb> <native_network_cidr>
+  local cb=$1 ncidr=$2 vid vline vcidr vids
+  "$cb" eth0 "$ncidr" access
+  [ "$SCAN_TAGGED_VLANS" = "1" ] || return
+  have ip || return; have udhcpc || return
+  lsmod 2>/dev/null | grep -q 8021q || modprobe 8021q 2>/dev/null
+  vids=$(vlan_candidates)
+  for vid in $vids; do
+    ip link add link eth0 name "eth0.$vid" type vlan id "$vid" 2>/dev/null
+    ip link show "eth0.$vid" >/dev/null 2>&1 || { say "VLAN $vid: no 802.1Q"; continue; }
+    ip link set "eth0.$vid" up 2>/dev/null
+    udhcpc -i "eth0.$vid" -n -q -t 4 -T 3 >/dev/null 2>&1
+    vline=$(ip addr show "eth0.$vid" 2>/dev/null | grep -oE 'inet [0-9.]+/[0-9]+' | head -1 | awk '{print $2}')
+    if [ -n "$vline" ]; then
+      vcidr=$(network_cidr "${vline%/*}" "${vline#*/}")
+      if [ "$vcidr" != "$ncidr" ]; then
+        VLAN_SUBNETS="$VLAN_SUBNETS ${vid}:${vcidr}"
+        "$cb" "eth0.$vid" "$vcidr" "vlan$vid"
+      fi
+    fi
+    ip link set "eth0.$vid" down 2>/dev/null
+    ip link del "eth0.$vid" 2>/dev/null
+  done
+}
+# ----------------------------------------------------------------------------
+
+# ------------------------------ PHASE: SETUP --------------------------------
+glow SETUP
+CLEAR_SCREEN 2>/dev/null
+say "Risky device hunt"
+if ! have nmap; then glow FAIL; say "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
+RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
+mkdir -p "$RUN"; REPORT="$RUN/summary.txt"
+ROWS="$RUN/_rows.tsv"; : > "$ROWS"
+
+
+# --------------------------- PHASE: NETWORK UP ------------------------------
+glow SPECIAL
+say "DHCP lease (eth0)"
+NETMODE DHCP_CLIENT 2>/dev/null
+WAIT_FOR_LINK 2>/dev/null            # framework: block until carrier is up (the race fix)
+# Bounded lease wait: WAIT_FOR_IP blocks forever, so keep our own timeout to fail
+# cleanly on a NAC'd / no-DHCP drop instead of running blind.
+IP=""; PREFIX=""
+for _ in $(seq 1 "$DHCP_WAIT_SECS"); do
+  line=$(ip -o -4 addr show eth0 2>/dev/null | awk '{print $4}')
+  if [ -n "$line" ]; then IP=${line%/*}; PREFIX=${line#*/}; break; fi
+  sleep 1
+done
+if [ -z "$IP" ]; then
+  glow FAIL; say "No lease - 802.1X?"
+  echo "FAILED: no DHCP lease on eth0 (NAC/802.1X, no DHCP, or dead drop)." > "$REPORT"
+  ALERT "No DHCP lease - see loot" 8 2>/dev/null; exit 1
+fi
+say "IP $IP/$PREFIX"
+
+
+# ----------------------- PHASE: DISCOVER + SCAN -----------------------------
+# Discover + fingerprint one (iface, cidr). Per-label raw files so the native
+# VLAN and each tagged VLAN accumulate into the same inventory.
+scan_one() {                                    # scan_one <iface> <cidr> <label>
+  local iface=$1 cidr=$2 label=$3 n OSFLAG=""
+  nmap -sn $NMAP_TIMING -e "$iface" -oG "$RUN/disc_$label.gnmap" "$cidr" >/dev/null 2>&1
+  awk '/Status: Up/{print $2}' "$RUN/disc_$label.gnmap" 2>/dev/null | sort -u > "$RUN/up_$label.txt"
+  n=$(wc -l < "$RUN/up_$label.txt" 2>/dev/null | tr -d ' '); [ -z "$n" ] && n=0
+  [ "$n" -eq 0 ] && return
+  say "$label: $n hosts"
+  [ "$OS_DETECT" = "1" ] && OSFLAG="-O --osscan-guess"
+  # shellcheck disable=SC2086
+  nmap -Pn $NMAP_TIMING --host-timeout "$HOST_TIMEOUT" $OSFLAG -sV -p "$PORTSET" \
+    --script http-title -e "$iface" -iL "$RUN/up_$label.txt" -oN "$RUN/services_$label.txt" >/dev/null 2>&1
+  [ "$SNMP_LOOKUP" = "1" ] && nmap -Pn -sU $NMAP_TIMING --host-timeout 40s -p161 --script snmp-sysdescr \
+    -e "$iface" -iL "$RUN/up_$label.txt" -oN "$RUN/snmp_$label.txt" >/dev/null 2>&1
+}
+
+glow STAGE1
+say "Discovering + scanning"
+spin_up "Scan (native + tagged VLANs)"
+NATIVE_CIDR=$(network_cidr "$IP" "$PREFIX")
+run_over_vlans scan_one "$NATIVE_CIDR"
+spin_down
+
+# Merge per-VLAN raw output into the combined files the classifier expects.
+cat "$RUN"/services_*.txt > "$RUN/services.txt" 2>/dev/null
+cat "$RUN"/snmp_*.txt     > "$RUN/snmp.txt"     2>/dev/null
+cat "$RUN"/up_*.txt 2>/dev/null | sort -u > "$RUN/up.txt"
+UPCOUNT=$(wc -l < "$RUN/up.txt" 2>/dev/null | tr -d ' '); [ -z "$UPCOUNT" ] && UPCOUNT=0
+say "$UPCOUNT hosts up"
+if [ "$UPCOUNT" -eq 0 ]; then
+  glow FAIL; echo "No live hosts discovered on $IP/$PREFIX (any VLAN)." > "$REPORT"
+  ALERT "No hosts found" 8 2>/dev/null; exit 0
+fi
+
+# SNMP sysDescr (printer/switch make + firmware) -> ip<TAB>descr
+: > "$RUN/snmp_map.tsv"
+[ -s "$RUN/snmp.txt" ] && awk '
+  /^Nmap scan report for /{ip=$0; sub(/^Nmap scan report for /,"",ip); if(ip~/\(.*\)/){sub(/.*\(/,"",ip);sub(/\)/,"",ip)}}
+  /snmp-sysdescr:/{d=$0; sub(/.*snmp-sysdescr: */,"",d); gsub(/\t/," ",d); if(ip!="")print ip"\t"d}
+' "$RUN/snmp.txt" 2>/dev/null > "$RUN/snmp_map.tsv"
+
+
+# --------------------------- PHASE: CLASSIFY --------------------------------
+glow STAGE4
+say "Classifying devices"
+CREATE_PROGRESS_BAR "Classifying" 2>/dev/null
+
+# Parse services.txt into per-host records: IP HOST MAC VENDOR OS PORTNUMS PORTSVC BANNER
+awk '
+  function flush(  i){
+    if(ip=="")return
+    pn=""; ps=""
+    for(i=1;i<=np;i++){ pn=pn (pn==""?"":",") pport[i]; ps=ps (ps==""?"":" ") pport[i]"/"psvc[i] }
+    gsub(/\t/," ",ban)
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", ip,host,mac,vendor,os,pn,ps,ban
+  }
+  /^Nmap scan report for /{ flush(); line=$0; sub(/^Nmap scan report for /,"",line)
+    if(line~/\(.*\)/){host=line;sub(/ \(.*/,"",host);ip=line;sub(/.*\(/,"",ip);sub(/\)/,"",ip)} else {host="-";ip=line}
+    mac="-";vendor="-";os="-";np=0;ban="" }
+  /^[0-9]+\/(tcp|udp)[ \t]+open/{ split($1,a,"/"); pport[++np]=a[1]; psvc[np]=$3
+    v=""; for(i=4;i<=NF;i++) v=v" "$i; ban=ban" " tolower($3 v) }
+  /^MAC Address: /{ mac=$3; vendor=$0; sub(/^MAC Address: [^ ]+ ?/,"",vendor); gsub(/^\(|\)$/,"",vendor); if(vendor=="")vendor="-"; ban=ban" " tolower(vendor) }
+  /^OS details:/{ os=$0; sub(/^OS details: /,"",os); ban=ban" " tolower($0) }
+  /^(Running|Aggressive OS guesses):/{ if(os=="-"){os=$0; sub(/^[^:]*: /,"",os)} ban=ban" " tolower($0) }
+  /http-title:/{ t=$0; sub(/.*http-title: */,"",t); ban=ban" " tolower(t) }
+  END{ flush() }
+' "$RUN/services.txt" 2>/dev/null > "$RUN/_hosts.tsv"
+
+TOTAL=$(wc -l < "$RUN/_hosts.tsv" 2>/dev/null | tr -d ' '); [ -z "$TOTAL" ] && TOTAL=0
+idx=0
+while IFS=$'\t' read -r hip hhost hmac hvend hos hpn hps hban; do
+  [ -z "$hip" ] && continue
+  idx=$((idx+1))
+  oui_lookup "$hmac"
+  # SNMP sysDescr enriches both the banner (classification) and the version.
+  SNMPD=$(awk -F'\t' -v ip="$hip" '$1==ip{print $2; exit}' "$RUN/snmp_map.tsv" 2>/dev/null)
+  LHAY="$hban $(echo "$SNMPD" | tr 'A-Z' 'a-z')"
+  # Manufacturer: real nmap vendor -> built-in OUI table -> banner/SNMP keyword guess.
+  MANU="$hvend"
+  if [ "$MANU" = "-" ] || [ "$MANU" = "Unknown" ]; then
+    if [ -n "$OUI_VENDOR" ]; then MANU="$OUI_VENDOR"
+    else g=$(guess_vendor "$LHAY"); [ -n "$g" ] && MANU="$g" || MANU="Unknown"; fi
+  fi
+  classify "$MANU" "$hos" "$hhost" "$hpn" "$LHAY"
+  # Version: OS details, else SNMP sysDescr, else "-".
+  VER="$hos"
+  if [ "$VER" = "-" ] || [ -z "$VER" ]; then VER="$SNMPD"; fi
+  [ -z "$VER" ] && VER="-"
+  VER=$(echo "$VER" | cut -c1-40)
+  DEVNAME="$CT"; [ "$hhost" != "-" ] && [ -n "$hhost" ] && DEVNAME="$CT ($hhost)"
+  PORTSDISP=$(echo "$hps" | cut -c1-46); [ -z "$PORTSDISP" ] && PORTSDISP="(none open)"
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+    "$(risk_rank "$CR")" "$CR" "$DEVNAME" "${MANU:--}" "$VER" "$hip" "$PORTSDISP" "$CRE" >> "$ROWS"
+  [ "$TOTAL" -gt 0 ] && SET_PROGRESS $(( idx * 100 / TOTAL )) 2>/dev/null
+done < "$RUN/_hosts.tsv"
+SET_PROGRESS 100 2>/dev/null
+
+
+# --------------------------- PHASE: WRITE LOOT ------------------------------
+glow CLEANUP
+say "Writing loot"
+FLAGGED=$(awk -F'\t' '$1<=3' "$ROWS" 2>/dev/null | wc -l | tr -d ' ')
+{
+  echo "=========================================================="
+  echo " SHARK JACK DISPLAY - ROGUE / RISKY DEVICE REPORT"
+  echo "=========================================================="
+  echo " Run time : $(date -u '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null)"
+  echo " From     : $IP/$PREFIX     Live hosts: $UPCOUNT     Flagged: $FLAGGED"
+  echo " VLANs    : native $(network_cidr "$IP" "$PREFIX")${VLAN_SUBNETS:+ ; tagged}${VLAN_SUBNETS}"
+  echo "            (host IPs identify their VLAN: e.g. .62.x = vlan3)"
+  echo ""
+  echo " RISK: HIGH = remove/verify now   MEDIUM = harden/patch   REVIEW = confirm owner"
+  echo ""
+  echo "##########################################################"
+  echo "#  FLAGGED FOR REVIEW (risky / unexpected)"
+  echo "##########################################################"
+  printf " %-6s  %-28s %-22s %-22s %-15s %s\n" "RISK" "DEVICE" "MANUFACTURER" "VERSION" "IP" "OPEN PORTS"
+  printf " %-6s  %-28s %-22s %-22s %-15s %s\n" "------" "----------------------------" "----------------------" "----------------------" "---------------" "----------"
+  sort -t"$(printf '\t')" -k1,1n "$ROWS" | awk -F'\t' '$1<=3{
+    printf " %-6s  %-28.28s %-22.22s %-22.22s %-15s %s\n", $2,$3,$4,$5,$6,$7
+  }'
+  echo ""
+  echo "   Why flagged:"
+  sort -t"$(printf '\t')" -k1,1n "$ROWS" | awk -F'\t' '$1<=3{printf "    %-15s %s - %s\n", $6, $3, $8}'
+  echo ""
+  echo "##########################################################"
+  echo "#  FULL INVENTORY (all live hosts)"
+  echo "##########################################################"
+  printf " %-6s  %-28s %-22s %-22s %-15s %s\n" "RISK" "DEVICE" "MANUFACTURER" "VERSION" "IP" "OPEN PORTS"
+  printf " %-6s  %-28s %-22s %-22s %-15s %s\n" "------" "----------------------------" "----------------------" "----------------------" "---------------" "----------"
+  sort -t"$(printf '\t')" -k1,1n "$ROWS" | awk -F'\t' '{
+    printf " %-6s  %-28.28s %-22.22s %-22.22s %-15s %s\n", $2,$3,$4,$5,$6,$7
+  }'
+  echo ""
+  echo "---- RAW ARTIFACTS ---------------------------------------"
+  echo " services.txt - combined nmap -sV -O output (all VLANs, per-host detail)"
+  echo " snmp.txt     - SNMP sysDescr (printer/switch firmware)"
+  echo " disc_*.gnmap services_*.txt - per-VLAN raw scans"
+  echo "=========================================================="
+} > "$REPORT"
+rm -f "$ROWS" "$RUN/_hosts.tsv" 2>/dev/null
+
+
+# ------------------------------ PHASE: DONE ---------------------------------
+glow FINISH
+CLEAR_SCREEN 2>/dev/null
+say "Risky hunt done"
+say "Flagged: $FLAGGED / $UPCOUNT"
+ALERT "Risky device scan done: $FLAGGED of $UPCOUNT hosts flagged for review." 12 2>/dev/null
+exit 0

--- a/payloads/library/recon/risky_devices/payload.txt
+++ b/payloads/library/recon/risky_devices/payload.txt
@@ -5,6 +5,7 @@
 #  Target:      An authorized wired drop, scoping a new environment.
 #  Category:    recon / assessment
 #  Version:     1.0
+#  Firmware:    Tested on Shark Jack Display 1.0.1
 # ----------------------------------------------------------------------------
 #  WHAT IT DOES
 #    Finds the devices nobody remembers plugging in and the ones that don't

--- a/payloads/library/recon/risky_devices/payload.txt
+++ b/payloads/library/recon/risky_devices/payload.txt
@@ -51,7 +51,6 @@ PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-glow() { LED "$@" 2>/dev/null; }
 spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
@@ -171,17 +170,17 @@ run_over_vlans() {                              # run_over_vlans <cb> <native_ne
 # ----------------------------------------------------------------------------
 
 # ------------------------------ PHASE: SETUP --------------------------------
-glow SETUP
+LED SETUP
 CLEAR_SCREEN 2>/dev/null
 say "Risky device hunt"
-if ! have nmap; then glow FAIL; say "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
+if ! have nmap; then LED FAIL; say "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
 RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
 mkdir -p "$RUN"; REPORT="$RUN/summary.txt"
 ROWS="$RUN/_rows.tsv"; : > "$ROWS"
 
 
 # --------------------------- PHASE: NETWORK UP ------------------------------
-glow SPECIAL
+LED SPECIAL
 say "DHCP lease (eth0)"
 NETMODE DHCP_CLIENT 2>/dev/null
 WAIT_FOR_LINK 2>/dev/null            # framework: block until carrier is up (the race fix)
@@ -194,7 +193,7 @@ for _ in $(seq 1 "$DHCP_WAIT_SECS"); do
   sleep 1
 done
 if [ -z "$IP" ]; then
-  glow FAIL; say "No lease - 802.1X?"
+  LED FAIL; say "No lease - 802.1X?"
   echo "FAILED: no DHCP lease on eth0 (NAC/802.1X, no DHCP, or dead drop)." > "$REPORT"
   ALERT "No DHCP lease - see loot" 8 2>/dev/null; exit 1
 fi
@@ -219,7 +218,7 @@ scan_one() {                                    # scan_one <iface> <cidr> <label
     -e "$iface" -iL "$RUN/up_$label.txt" -oN "$RUN/snmp_$label.txt" >/dev/null 2>&1
 }
 
-glow STAGE1
+LED STAGE1
 say "Discovering + scanning"
 spin_up "Scan (native + tagged VLANs)"
 NATIVE_CIDR=$(network_cidr "$IP" "$PREFIX")
@@ -233,7 +232,7 @@ cat "$RUN"/up_*.txt 2>/dev/null | sort -u > "$RUN/up.txt"
 UPCOUNT=$(wc -l < "$RUN/up.txt" 2>/dev/null | tr -d ' '); [ -z "$UPCOUNT" ] && UPCOUNT=0
 say "$UPCOUNT hosts up"
 if [ "$UPCOUNT" -eq 0 ]; then
-  glow FAIL; echo "No live hosts discovered on $IP/$PREFIX (any VLAN)." > "$REPORT"
+  LED FAIL; echo "No live hosts discovered on $IP/$PREFIX (any VLAN)." > "$REPORT"
   ALERT "No hosts found" 8 2>/dev/null; exit 0
 fi
 
@@ -246,7 +245,7 @@ fi
 
 
 # --------------------------- PHASE: CLASSIFY --------------------------------
-glow STAGE4
+LED STAGE4
 say "Classifying devices"
 CREATE_PROGRESS_BAR "Classifying" 2>/dev/null
 
@@ -302,7 +301,7 @@ SET_PROGRESS 100 2>/dev/null
 
 
 # --------------------------- PHASE: WRITE LOOT ------------------------------
-glow CLEANUP
+LED CLEANUP
 say "Writing loot"
 FLAGGED=$(awk -F'\t' '$1<=3' "$ROWS" 2>/dev/null | wc -l | tr -d ' ')
 {
@@ -347,7 +346,7 @@ rm -f "$ROWS" "$RUN/_hosts.tsv" 2>/dev/null
 
 
 # ------------------------------ PHASE: DONE ---------------------------------
-glow FINISH
+LED FINISH
 CLEAR_SCREEN 2>/dev/null
 say "Risky hunt done"
 say "Flagged: $FLAGGED / $UPCOUNT"

--- a/payloads/library/recon/risky_devices/payload.txt
+++ b/payloads/library/recon/risky_devices/payload.txt
@@ -51,7 +51,6 @@ PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
@@ -220,7 +219,7 @@ scan_one() {                                    # scan_one <iface> <cidr> <label
 
 LED STAGE1
 say "Discovering + scanning"
-spin_up "Scan (native + tagged VLANs)"
+CREATE_SPINNER "Scan (native + tagged VLANs)"
 NATIVE_CIDR=$(network_cidr "$IP" "$PREFIX")
 run_over_vlans scan_one "$NATIVE_CIDR"
 spin_down

--- a/payloads/library/recon/risky_devices/payload.txt
+++ b/payloads/library/recon/risky_devices/payload.txt
@@ -35,13 +35,13 @@
 DHCP_WAIT_SECS=30
 NMAP_TIMING="-T4"
 HOST_TIMEOUT="120s"
-OS_DETECT=1                     # 1 = nmap -O (helps tell a server from a laptop)
-SNMP_LOOKUP=1                   # 1 = pull SNMP sysDescr (printer/switch firmware)
+OS_DETECT=1                   # 1 = nmap -O (helps tell a server from a laptop)
+SNMP_LOOKUP=1                 # 1 = pull SNMP sysDescr (printer/switch firmware)
 # Classification-signal ports (kept short for speed + signal).
 PORTSET="21,22,23,25,53,80,110,143,443,445,515,554,623,631,1883,1900,2375,2376,3000,3306,3389,5000,5060,5432,5900,6379,7547,8000,8080,8443,8888,9000,9100,9200,27017"
 LOOT_BASE="/root/loot/risky"
 # VLAN-aware scanning: also tag onto and scan tagged VLANs seen on a trunk.
-SCAN_TAGGED_VLANS=0            # 1 = discover+scan tagged VLANs too. ACTIVE VLAN-
+SCAN_TAGGED_VLANS=0           # 1 = discover+scan tagged VLANs too. ACTIVE VLAN-
                               #     hopping; set 0 for client sites unless it is
                               #     authorized. No-op on a plain access port.
 VLAN_PROBE_IDS=""             # fallback VIDs if none are sniffed, e.g. "2 3 10"

--- a/payloads/library/recon/risky_devices/payload.txt
+++ b/payloads/library/recon/risky_devices/payload.txt
@@ -51,7 +51,6 @@ PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
 # Built-in OUI table for the high-signal DIY devices nmap's DB often misses.
@@ -222,7 +221,7 @@ say "Discovering + scanning"
 CREATE_SPINNER "Scan (native + tagged VLANs)"
 NATIVE_CIDR=$(network_cidr "$IP" "$PREFIX")
 run_over_vlans scan_one "$NATIVE_CIDR"
-spin_down
+STOP_SPINNER
 
 # Merge per-VLAN raw output into the combined files the classifier expects.
 cat "$RUN"/services_*.txt > "$RUN/services.txt" 2>/dev/null

--- a/payloads/library/recon/risky_devices/payload.txt
+++ b/payloads/library/recon/risky_devices/payload.txt
@@ -50,7 +50,6 @@ PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
 # ----------------------------------------------------------------------------
 
 # ============================ helpers =======================================
-say()  { SCREEN_WRITE "$*" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
 # Built-in OUI table for the high-signal DIY devices nmap's DB often misses.
@@ -150,7 +149,7 @@ run_over_vlans() {                              # run_over_vlans <cb> <native_ne
   vids=$(vlan_candidates)
   for vid in $vids; do
     ip link add link eth0 name "eth0.$vid" type vlan id "$vid" 2>/dev/null
-    ip link show "eth0.$vid" >/dev/null 2>&1 || { say "VLAN $vid: no 802.1Q"; continue; }
+    ip link show "eth0.$vid" >/dev/null 2>&1 || { SCREEN_WRITE "VLAN $vid: no 802.1Q"; continue; }
     ip link set "eth0.$vid" up 2>/dev/null
     udhcpc -i "eth0.$vid" -n -q -t 4 -T 3 >/dev/null 2>&1
     vline=$(ip addr show "eth0.$vid" 2>/dev/null | grep -oE 'inet [0-9.]+/[0-9]+' | head -1 | awk '{print $2}')
@@ -170,8 +169,8 @@ run_over_vlans() {                              # run_over_vlans <cb> <native_ne
 # ------------------------------ PHASE: SETUP --------------------------------
 LED SETUP
 CLEAR_SCREEN 2>/dev/null
-say "Risky device hunt"
-if ! have nmap; then LED FAIL; say "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
+SCREEN_WRITE "Risky device hunt"
+if ! have nmap; then LED FAIL; SCREEN_WRITE "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
 RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
 mkdir -p "$RUN"; REPORT="$RUN/summary.txt"
 ROWS="$RUN/_rows.tsv"; : > "$ROWS"
@@ -179,7 +178,7 @@ ROWS="$RUN/_rows.tsv"; : > "$ROWS"
 
 # --------------------------- PHASE: NETWORK UP ------------------------------
 LED SPECIAL
-say "DHCP lease (eth0)"
+SCREEN_WRITE "DHCP lease (eth0)"
 NETMODE DHCP_CLIENT 2>/dev/null
 WAIT_FOR_LINK 2>/dev/null            # framework: block until carrier is up (the race fix)
 # Bounded lease wait: WAIT_FOR_IP blocks forever, so keep our own timeout to fail
@@ -191,11 +190,11 @@ for _ in $(seq 1 "$DHCP_WAIT_SECS"); do
   sleep 1
 done
 if [ -z "$IP" ]; then
-  LED FAIL; say "No lease - 802.1X?"
+  LED FAIL; SCREEN_WRITE "No lease - 802.1X?"
   echo "FAILED: no DHCP lease on eth0 (NAC/802.1X, no DHCP, or dead drop)." > "$REPORT"
   ALERT "No DHCP lease - see loot" 8 2>/dev/null; exit 1
 fi
-say "IP $IP/$PREFIX"
+SCREEN_WRITE "IP $IP/$PREFIX"
 
 
 # ----------------------- PHASE: DISCOVER + SCAN -----------------------------
@@ -207,7 +206,7 @@ scan_one() {                                    # scan_one <iface> <cidr> <label
   awk '/Status: Up/{print $2}' "$RUN/disc_$label.gnmap" 2>/dev/null | sort -u > "$RUN/up_$label.txt"
   n=$(wc -l < "$RUN/up_$label.txt" 2>/dev/null | tr -d ' '); [ -z "$n" ] && n=0
   [ "$n" -eq 0 ] && return
-  say "$label: $n hosts"
+  SCREEN_WRITE "$label: $n hosts"
   [ "$OS_DETECT" = "1" ] && OSFLAG="-O --osscan-guess"
   # shellcheck disable=SC2086
   nmap -Pn $NMAP_TIMING --host-timeout "$HOST_TIMEOUT" $OSFLAG -sV -p "$PORTSET" \
@@ -217,7 +216,7 @@ scan_one() {                                    # scan_one <iface> <cidr> <label
 }
 
 LED STAGE1
-say "Discovering + scanning"
+SCREEN_WRITE "Discovering + scanning"
 CREATE_SPINNER "Scan (native + tagged VLANs)"
 NATIVE_CIDR=$(network_cidr "$IP" "$PREFIX")
 run_over_vlans scan_one "$NATIVE_CIDR"
@@ -228,7 +227,7 @@ cat "$RUN"/services_*.txt > "$RUN/services.txt" 2>/dev/null
 cat "$RUN"/snmp_*.txt     > "$RUN/snmp.txt"     2>/dev/null
 cat "$RUN"/up_*.txt 2>/dev/null | sort -u > "$RUN/up.txt"
 UPCOUNT=$(wc -l < "$RUN/up.txt" 2>/dev/null | tr -d ' '); [ -z "$UPCOUNT" ] && UPCOUNT=0
-say "$UPCOUNT hosts up"
+SCREEN_WRITE "$UPCOUNT hosts up"
 if [ "$UPCOUNT" -eq 0 ]; then
   LED FAIL; echo "No live hosts discovered on $IP/$PREFIX (any VLAN)." > "$REPORT"
   ALERT "No hosts found" 8 2>/dev/null; exit 0
@@ -244,7 +243,7 @@ fi
 
 # --------------------------- PHASE: CLASSIFY --------------------------------
 LED STAGE4
-say "Classifying devices"
+SCREEN_WRITE "Classifying devices"
 CREATE_PROGRESS_BAR "Classifying" 2>/dev/null
 
 # Parse services.txt into per-host records: IP HOST MAC VENDOR OS PORTNUMS PORTSVC BANNER
@@ -300,7 +299,7 @@ SET_PROGRESS 100 2>/dev/null
 
 # --------------------------- PHASE: WRITE LOOT ------------------------------
 LED CLEANUP
-say "Writing loot"
+SCREEN_WRITE "Writing loot"
 FLAGGED=$(awk -F'\t' '$1<=3' "$ROWS" 2>/dev/null | wc -l | tr -d ' ')
 {
   echo "=========================================================="
@@ -346,7 +345,7 @@ rm -f "$ROWS" "$RUN/_hosts.tsv" 2>/dev/null
 # ------------------------------ PHASE: DONE ---------------------------------
 LED FINISH
 CLEAR_SCREEN 2>/dev/null
-say "Risky hunt done"
-say "Flagged: $FLAGGED / $UPCOUNT"
+SCREEN_WRITE "Risky hunt done"
+SCREEN_WRITE "Flagged: $FLAGGED / $UPCOUNT"
 ALERT "Risky device scan done: $FLAGGED of $UPCOUNT hosts flagged for review." 12 2>/dev/null
 exit 0

--- a/payloads/library/recon/segmentation_egress/README.md
+++ b/payloads/library/recon/segmentation_egress/README.md
@@ -1,0 +1,67 @@
+# Shark Jack Display - Segmentation + Egress Check
+
+Characterizes what this one drop is allowed to reach: which outbound ports
+actually escape, whether the path is direct / captive-portal / proxied / SSL-
+inspected, which gateway admin ports answer from a user drop, and whether you can
+reach the sensitive internal targets you list.
+
+> **Authorized use only.** Run only on networks you own or are contracted to
+> assess, within the agreed scope and time window. This payload sends probes to a
+> configurable external IP and to the internal targets YOU specify: only set
+> `SEG_TARGETS` to ranges the engagement authorizes. Nothing is exfiltrated: all
+> output stays on-device under `/root/loot/segmentation/` until you retrieve it.
+>
+
+## What it checks
+
+| Section | What you learn |
+|---------|----------------|
+| **Egress** | which outbound TCP ports escape to the internet (open/closed = allowed, filtered = blocked), plus outbound DNS |
+| **Internet path** | direct vs captive-portal/proxy vs blocked; the cert issuer for an external HTTPS host (an internal CA issuer means SSL inspection) |
+| **Gateway mgmt** | which admin ports on the gateway answer from a user drop (mgmt reachable from a user VLAN is a finding) |
+| **Segmentation** | reachability to the sensitive internal targets you list in `SEG_TARGETS` |
+
+## Output (loot)
+
+`/root/loot/segmentation/<UTC-timestamp>_<pid>/`:
+
+```
+summary.txt        <- read this first
+egress_tcp.txt egress_udp53.txt http_probe.txt
+gateway_mgmt.txt   segmentation.txt (when SEG_TARGETS set)
+vlan_egress.txt    <- per tagged-VLAN egress (when SCAN_TAGGED_VLANS=1)
+```
+
+## Configuration (top of [`payload.txt`](payload.txt))
+
+| Knob | Default | Notes |
+|------|---------|-------|
+| `DHCP_WAIT_SECS` | `30` | wait for a lease before failing |
+| `EXT_IP` | `1.1.1.1` | external egress probe target. Point at an authorized/known target if a public resolver is not acceptable in your engagement |
+| `EXT_HOST` | `example.com` | external hostname for HTTP/TLS path tests (RFC 2606 reserved documentation domain) |
+| `EGRESS_PORTS` | common set | outbound ports to test |
+| `SEG_TARGETS` | `""` | internal ranges to test reachability TO. Empty = gateway mgmt surface only. **Authorized scope only** |
+| `SEG_PORTS` | common set | ports to test against `SEG_TARGETS` |
+| `SCAN_TAGGED_VLANS` | `1` | **active VLAN-hopping** on a trunk; set `0` for client sites unless explicitly authorized |
+| `VLAN_PROBE_IDS` | `""` | fallback VIDs if none are sniffed |
+| `PASSIVE_VLAN_SECS` | `12` | passive 802.1Q listen window (needs `tcpdump`) |
+| `LOOT_BASE` | `/root/loot/segmentation` | where loot lands |
+
+## Requirements
+
+- **`nmap`** (ships on the device). Optional: **`wget`** or **`curl`** and
+  **`openssl`** for the HTTP/TLS internet-path test (it degrades gracefully if
+  absent).
+
+## LED / screen cues
+
+`SETUP` -> `SPECIAL` (lease) -> `STAGE1` egress -> `STAGE2` internet path ->
+`STAGE3` gateway mgmt -> `STAGE4` segmentation -> `STAGE5` per-VLAN -> `CLEANUP`
+-> `FINISH`. Red `FAIL` means no DHCP lease.
+
+## Notes
+
+- `SEG_TARGETS` is empty by default on purpose: with no internal targets set, the
+  payload only profiles egress and the gateway management surface.
+- `SCAN_TAGGED_VLANS=1` is active VLAN-hopping: noisy and intrusive. It no-ops on
+  a plain access port. Leave it `0` unless the engagement authorizes it.

--- a/payloads/library/recon/segmentation_egress/payload.txt
+++ b/payloads/library/recon/segmentation_egress/payload.txt
@@ -46,7 +46,6 @@ PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-glow() { LED "$@" 2>/dev/null; }
 spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
@@ -103,16 +102,16 @@ run_over_vlans() {                              # run_over_vlans <cb> <native_ne
 # ----------------------------------------------------------------------------
 
 # ------------------------------ PHASE: SETUP --------------------------------
-glow SETUP
+LED SETUP
 CLEAR_SCREEN 2>/dev/null
 say "Segmentation + egress"
-if ! have nmap; then glow FAIL; say "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
+if ! have nmap; then LED FAIL; say "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
 RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
 mkdir -p "$RUN"; REPORT="$RUN/summary.txt"
 
 
 # --------------------------- PHASE: NETWORK UP ------------------------------
-glow SPECIAL
+LED SPECIAL
 say "DHCP lease (eth0)"
 NETMODE DHCP_CLIENT 2>/dev/null
 WAIT_FOR_LINK 2>/dev/null            # framework: block until carrier is up (the race fix)
@@ -125,7 +124,7 @@ for _ in $(seq 1 "$DHCP_WAIT_SECS"); do
   sleep 1
 done
 if [ -z "$IP" ]; then
-  glow FAIL; say "No lease - 802.1X?"
+  LED FAIL; say "No lease - 802.1X?"
   echo "FAILED: no DHCP lease on eth0 (NAC/802.1X, no DHCP, or dead drop)." > "$REPORT"
   ALERT "No DHCP lease - see loot" 8 2>/dev/null; exit 1
 fi
@@ -134,7 +133,7 @@ say "IP $IP/$PREFIX"
 
 
 # ----------------------------- PHASE: EGRESS --------------------------------
-glow STAGE1
+LED STAGE1
 say "Testing egress"
 spin_up "Outbound TCP -> $EXT_IP"
 nmap -Pn --reason -T4 -p "$EGRESS_PORTS" "$EXT_IP" -oN "$RUN/egress_tcp.txt" >/dev/null 2>&1
@@ -149,7 +148,7 @@ UDP53=$(awk '/^53\/udp/{print ($2=="open"||$2=="open|filtered")?"allowed":"block
 
 
 # -------------------------- PHASE: INTERNET PATH ----------------------------
-glow STAGE2
+LED STAGE2
 say "Internet path"
 spin_up "HTTP/TLS path"
 BODY=""
@@ -170,7 +169,7 @@ spin_down
 
 
 # ------------------------- PHASE: GW MGMT + SEGMENTATION --------------------
-glow STAGE3
+LED STAGE3
 say "Gateway mgmt"
 spin_up "Gateway admin ports"
 nmap -Pn -T4 -p22,23,80,443,8443 "$GATEWAY" -oN "$RUN/gateway_mgmt.txt" >/dev/null 2>&1
@@ -179,7 +178,7 @@ GW_OPEN=$(awk '/^[0-9]+\/tcp[ \t]+open/{split($1,a,"/"); printf "%s/%s ", a[1], 
 
 SEG_RESULT="not tested (SEG_TARGETS empty)"
 if [ -n "$SEG_TARGETS" ]; then
-  glow STAGE4
+  LED STAGE4
   say "Segmentation probe"
   spin_up "Reaching SEG_TARGETS"
   # shellcheck disable=SC2086
@@ -213,14 +212,14 @@ scan_one() {                                    # scan_one <iface> <cidr> <label
   } >> "$RUN/vlan_egress.txt"
 }
 if [ "$SCAN_TAGGED_VLANS" = "1" ]; then
-  glow STAGE5
+  LED STAGE5
   say "Per-VLAN egress"
   run_over_vlans scan_one "$(network_cidr "$IP" "$PREFIX")"
 fi
 
 
 # --------------------------- PHASE: WRITE LOOT ------------------------------
-glow CLEANUP
+LED CLEANUP
 say "Writing loot"
 {
   echo "=========================================================="
@@ -257,7 +256,7 @@ say "Writing loot"
 
 
 # ------------------------------ PHASE: DONE ---------------------------------
-glow FINISH
+LED FINISH
 CLEAR_SCREEN 2>/dev/null
 say "Seg/egress done"
 say "Egress: ${EG_ALLOW:-none}"

--- a/payloads/library/recon/segmentation_egress/payload.txt
+++ b/payloads/library/recon/segmentation_egress/payload.txt
@@ -5,6 +5,7 @@
 #  Target:      An authorized wired drop, scoping a new environment.
 #  Category:    recon / assessment
 #  Version:     1.0
+#  Firmware:    Tested on Shark Jack Display 1.0.1
 # ----------------------------------------------------------------------------
 #  WHAT IT DOES
 #    Characterizes what this one drop is allowed to reach:

--- a/payloads/library/recon/segmentation_egress/payload.txt
+++ b/payloads/library/recon/segmentation_egress/payload.txt
@@ -1,0 +1,264 @@
+#!/bin/bash
+# ============================================================================
+#  Title:       Segmentation + Egress Check (Shark Jack Display)
+#  Author:      Brent Mills
+#  Target:      An authorized wired drop, scoping a new environment.
+#  Category:    recon / assessment
+#  Version:     1.0
+# ----------------------------------------------------------------------------
+#  WHAT IT DOES
+#    Characterizes what this one drop is allowed to reach:
+#      - Egress ........... which outbound ports actually escape to the internet
+#                           (open/closed = allowed, filtered = blocked).
+#      - Internet path .... direct vs captive-portal/proxy vs blocked; and the
+#                           cert issuer seen for an external HTTPS site (an
+#                           internal-CA issuer means SSL inspection is in play).
+#      - Gateway mgmt ..... which admin ports on the gateway answer from a user
+#                           drop (mgmt reachable from a user VLAN is a finding).
+#      - Segmentation ..... reachability to the sensitive internal targets you
+#                           list in SEG_TARGETS (server/mgmt VLANs, etc).
+#
+#  AUTHORIZATION
+#    Sends a small number of probes to a configurable external IP and to the
+#    internal targets YOU specify. Run on in-scope networks only, and only set
+#    SEG_TARGETS to ranges the engagement authorizes you to test. Output stays
+#    on-device in /root/loot until you pull it.
+# ============================================================================
+
+# ------------------------------- CONFIG -------------------------------------
+DHCP_WAIT_SECS=30
+EXT_IP="example.com"               # external probe target (stable, benign)
+EXT_HOST="example.com"         # external hostname for HTTP/TLS path tests
+EGRESS_PORTS="22,25,53,80,443,123,445,3389,1433,8080,8443"
+SEG_TARGETS=""                 # internal ranges/IPs to test reachability TO,
+                               # e.g. "10.10.10.0/24 10.20.0.1". Empty = gateway
+                               # mgmt surface only. Authorized scope ONLY.
+SEG_PORTS="22,23,80,443,445,3389,8443"
+LOOT_BASE="/root/loot/segmentation"
+# VLAN-aware scanning: also tag onto and scan tagged VLANs seen on a trunk.
+SCAN_TAGGED_VLANS=0            # 1 = discover+scan tagged VLANs too. ACTIVE VLAN-
+                              #     hopping; set 0 for client sites unless it is
+                              #     authorized. No-op on a plain access port.
+VLAN_PROBE_IDS=""             # fallback VIDs if none are sniffed, e.g. "2 3 10"
+PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
+# ----------------------------------------------------------------------------
+
+# ============================ helpers =======================================
+say()  { SCREEN_WRITE "$*" 2>/dev/null; }
+glow() { LED "$@" 2>/dev/null; }
+spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
+spin_down() { STOP_SPINNER 2>/dev/null; }
+have() { command -v "$1" >/dev/null 2>&1; }
+# ============================================================================
+
+
+# ---- VLAN-aware scanning (shared block; keep identical across payloads) -----
+ip_to_int() { local IFS=.; set -- $1; echo $(( ($1<<24)|($2<<16)|($3<<8)|$4 )); }
+int_to_ip() { local i=$1; echo "$(((i>>24)&255)).$(((i>>16)&255)).$(((i>>8)&255)).$((i&255))"; }
+mask_for()  { local p=$1; echo $(( (0xFFFFFFFF << (32-p)) & 0xFFFFFFFF )); }
+network_cidr() { local ip=$1 p=$2 m; m=$(mask_for "$p"); echo "$(int_to_ip $(( $(ip_to_int "$ip") & m )))/$p"; }
+VLAN_SUBNETS=""                                 # "vid:net/prefix ..." for labeling
+vlan_for_ip() {
+  local ip=$1 ipi entry vid cidr net p m; ipi=$(ip_to_int "$ip")
+  for entry in $VLAN_SUBNETS; do
+    vid=${entry%%:*}; cidr=${entry#*:}; net=${cidr%/*}; p=${cidr#*/}; m=$(mask_for "$p")
+    [ $(( ipi & m )) -eq $(( $(ip_to_int "$net") & m )) ] && { echo "vlan$vid"; return; }
+  done
+  echo "access"
+}
+vlan_candidates() {                             # VIDs to scan: sniffed 802.1Q tags, else fallback
+  local tags=""
+  have tcpdump && tags=$(timeout "${PASSIVE_VLAN_SECS}s" tcpdump -e -nn -i eth0 -c 300 vlan 2>/dev/null \
+    | grep -oE 'vlan [0-9]+' | awk '{print $2}' | sort -un | tr '\n' ' ')
+  [ -z "$tags" ] && tags="$VLAN_PROBE_IDS"
+  echo "$tags"
+}
+# Run <cb> over the native VLAN, then (if enabled) each tagged VLAN: bring up
+# eth0.<vid>, DHCP, derive its CIDR, call "<cb> <iface> <cidr> <label>", tear down.
+run_over_vlans() {                              # run_over_vlans <cb> <native_network_cidr>
+  local cb=$1 ncidr=$2 vid vline vcidr vids
+  "$cb" eth0 "$ncidr" access
+  [ "$SCAN_TAGGED_VLANS" = "1" ] || return
+  have ip || return; have udhcpc || return
+  lsmod 2>/dev/null | grep -q 8021q || modprobe 8021q 2>/dev/null
+  vids=$(vlan_candidates)
+  for vid in $vids; do
+    ip link add link eth0 name "eth0.$vid" type vlan id "$vid" 2>/dev/null
+    ip link show "eth0.$vid" >/dev/null 2>&1 || { say "VLAN $vid: no 802.1Q"; continue; }
+    ip link set "eth0.$vid" up 2>/dev/null
+    udhcpc -i "eth0.$vid" -n -q -t 4 -T 3 >/dev/null 2>&1
+    vline=$(ip addr show "eth0.$vid" 2>/dev/null | grep -oE 'inet [0-9.]+/[0-9]+' | head -1 | awk '{print $2}')
+    if [ -n "$vline" ]; then
+      vcidr=$(network_cidr "${vline%/*}" "${vline#*/}")
+      if [ "$vcidr" != "$ncidr" ]; then
+        VLAN_SUBNETS="$VLAN_SUBNETS ${vid}:${vcidr}"
+        "$cb" "eth0.$vid" "$vcidr" "vlan$vid"
+      fi
+    fi
+    ip link set "eth0.$vid" down 2>/dev/null
+    ip link del "eth0.$vid" 2>/dev/null
+  done
+}
+# ----------------------------------------------------------------------------
+
+# ------------------------------ PHASE: SETUP --------------------------------
+glow SETUP
+CLEAR_SCREEN 2>/dev/null
+say "Segmentation + egress"
+if ! have nmap; then glow FAIL; say "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
+RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
+mkdir -p "$RUN"; REPORT="$RUN/summary.txt"
+
+
+# --------------------------- PHASE: NETWORK UP ------------------------------
+glow SPECIAL
+say "DHCP lease (eth0)"
+NETMODE DHCP_CLIENT 2>/dev/null
+WAIT_FOR_LINK 2>/dev/null            # framework: block until carrier is up (the race fix)
+# Bounded lease wait: WAIT_FOR_IP blocks forever, so keep our own timeout to fail
+# cleanly on a NAC'd / no-DHCP drop instead of running blind.
+IP=""; PREFIX=""
+for _ in $(seq 1 "$DHCP_WAIT_SECS"); do
+  line=$(ip -o -4 addr show eth0 2>/dev/null | awk '{print $4}')
+  if [ -n "$line" ]; then IP=${line%/*}; PREFIX=${line#*/}; break; fi
+  sleep 1
+done
+if [ -z "$IP" ]; then
+  glow FAIL; say "No lease - 802.1X?"
+  echo "FAILED: no DHCP lease on eth0 (NAC/802.1X, no DHCP, or dead drop)." > "$REPORT"
+  ALERT "No DHCP lease - see loot" 8 2>/dev/null; exit 1
+fi
+GATEWAY=$(ip route 2>/dev/null | awk '/default/{print $3; exit}')
+say "IP $IP/$PREFIX"
+
+
+# ----------------------------- PHASE: EGRESS --------------------------------
+glow STAGE1
+say "Testing egress"
+spin_up "Outbound TCP -> $EXT_IP"
+nmap -Pn --reason -T4 -p "$EGRESS_PORTS" "$EXT_IP" -oN "$RUN/egress_tcp.txt" >/dev/null 2>&1
+nmap -Pn -sU -p53 "$EXT_IP" -oN "$RUN/egress_udp53.txt" >/dev/null 2>&1
+spin_down
+# open|closed => our SYN reached the internet (egress allowed); filtered => blocked.
+EG=$(awk '/^[0-9]+\/tcp/{ split($1,a,"/"); p=a[1]; if($2=="open"||$2=="closed") al=al" "p; else bl=bl" "p }
+         END{ printf "ALLOWED:%s\nBLOCKED:%s\n", al, bl }' "$RUN/egress_tcp.txt" 2>/dev/null)
+EG_ALLOW=$(echo "$EG" | sed -n 's/^ALLOWED://p' | sed 's/^ *//')
+EG_BLOCK=$(echo "$EG" | sed -n 's/^BLOCKED://p' | sed 's/^ *//')
+UDP53=$(awk '/^53\/udp/{print ($2=="open"||$2=="open|filtered")?"allowed":"blocked"}' "$RUN/egress_udp53.txt" 2>/dev/null)
+
+
+# -------------------------- PHASE: INTERNET PATH ----------------------------
+glow STAGE2
+say "Internet path"
+spin_up "HTTP/TLS path"
+BODY=""
+if have wget; then BODY=$(wget -q -O- --timeout=6 "http://$EXT_HOST" 2>/dev/null)
+elif have curl; then BODY=$(curl -s -m 6 "http://$EXT_HOST" 2>/dev/null); fi
+echo "$BODY" > "$RUN/http_probe.txt"
+if echo "$BODY" | grep -qi "Example Domain"; then NETPATH="direct (open web egress)"
+elif [ -n "$BODY" ]; then NETPATH="altered response (captive portal or proxy) - see http_probe.txt"
+else NETPATH="no HTTP egress (blocked or proxy-only)"; fi
+# Cert issuer for an external HTTPS host: an internal CA here == SSL inspection.
+ISSUER="-"
+if have openssl; then
+  ISSUER=$(echo | openssl s_client -connect "${EXT_HOST}:443" -servername "$EXT_HOST" 2>/dev/null \
+           | openssl x509 -noout -issuer 2>/dev/null | sed 's/^issuer= *//')
+  [ -z "$ISSUER" ] && ISSUER="(no TLS handshake - egress blocked or proxied)"
+fi
+spin_down
+
+
+# ------------------------- PHASE: GW MGMT + SEGMENTATION --------------------
+glow STAGE3
+say "Gateway mgmt"
+spin_up "Gateway admin ports"
+nmap -Pn -T4 -p22,23,80,443,8443 "$GATEWAY" -oN "$RUN/gateway_mgmt.txt" >/dev/null 2>&1
+spin_down
+GW_OPEN=$(awk '/^[0-9]+\/tcp[ \t]+open/{split($1,a,"/"); printf "%s/%s ", a[1], $3}' "$RUN/gateway_mgmt.txt" 2>/dev/null)
+
+SEG_RESULT="not tested (SEG_TARGETS empty)"
+if [ -n "$SEG_TARGETS" ]; then
+  glow STAGE4
+  say "Segmentation probe"
+  spin_up "Reaching SEG_TARGETS"
+  # shellcheck disable=SC2086
+  nmap -Pn -T4 -p "$SEG_PORTS" $SEG_TARGETS -oG "$RUN/segmentation.gnmap" -oN "$RUN/segmentation.txt" >/dev/null 2>&1
+  spin_down
+  SEG_HOSTS=$(awk -F'\t' '/Ports:/ && /open/{print $0}' "$RUN/segmentation.gnmap" 2>/dev/null \
+              | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | sort -u | tr '\n' ' ')
+  if [ -n "$SEG_HOSTS" ]; then SEG_RESULT="REACHABLE (segmentation gap): $SEG_HOSTS"
+  else SEG_RESULT="no listed targets reachable on $SEG_PORTS (segmented)"; fi
+fi
+
+
+# ----------------------- PHASE: PER-VLAN EGRESS -----------------------------
+# For each tagged VLAN: does IT have egress, and is its gateway admin reachable?
+# (Native tested above on the native route; scan_one skips the "access" label.
+#  udhcpc points the default route at each VLAN's gateway as we go.)
+: > "$RUN/vlan_egress.txt"
+scan_one() {                                    # scan_one <iface> <cidr> <label>
+  local iface=$1 cidr=$2 label=$3 gw egal gwopen
+  [ "$label" = "access" ] && return
+  say "$label: egress + gw"
+  gw=$(ip route 2>/dev/null | awk -v d="$iface" '/default/ && $0 ~ ("dev "d){print $3; exit}')
+  [ -z "$gw" ] && gw=$(echo "$cidr" | sed 's,0/.*,1,')
+  nmap -Pn --reason -T4 -e "$iface" -p "$EGRESS_PORTS" "$EXT_IP" -oN "$RUN/egress_$label.txt" >/dev/null 2>&1
+  egal=$(awk '/^[0-9]+\/tcp/{split($1,a,"/"); if($2=="open"||$2=="closed") s=s" "a[1]} END{print s}' "$RUN/egress_$label.txt" 2>/dev/null | sed 's/^ *//')
+  nmap -Pn -T4 -e "$iface" -p22,23,80,443,8443 "$gw" -oN "$RUN/gwmgmt_$label.txt" >/dev/null 2>&1
+  gwopen=$(awk '/^[0-9]+\/tcp[ \t]+open/{split($1,a,"/"); printf "%s/%s ",a[1],$3}' "$RUN/gwmgmt_$label.txt" 2>/dev/null)
+  { echo " $label  ($cidr, gw $gw)"
+    echo "   Egress allowed : ${egal:-none}"
+    echo "   GW admin open  : ${gwopen:-none}"
+  } >> "$RUN/vlan_egress.txt"
+}
+if [ "$SCAN_TAGGED_VLANS" = "1" ]; then
+  glow STAGE5
+  say "Per-VLAN egress"
+  run_over_vlans scan_one "$(network_cidr "$IP" "$PREFIX")"
+fi
+
+
+# --------------------------- PHASE: WRITE LOOT ------------------------------
+glow CLEANUP
+say "Writing loot"
+{
+  echo "=========================================================="
+  echo " SHARK JACK DISPLAY - SEGMENTATION + EGRESS"
+  echo "=========================================================="
+  echo " Run time : $(date -u '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null)"
+  echo " Our lease: $IP/$PREFIX     Gateway: ${GATEWAY:-unknown}"
+  echo ""
+  echo "---- EGRESS (outbound to $EXT_IP) ------------------------"
+  echo " Allowed TCP ports : ${EG_ALLOW:-none}"
+  echo " Blocked TCP ports : ${EG_BLOCK:-none}"
+  echo " Outbound DNS (UDP/53): ${UDP53:-unknown}"
+  echo ""
+  echo "---- INTERNET PATH ---------------------------------------"
+  echo " HTTP path     : $NETPATH"
+  echo " Ext TLS issuer: $ISSUER"
+  echo "   (an internal/corporate CA issuer here means SSL inspection)"
+  echo ""
+  echo "---- GATEWAY MGMT EXPOSURE -------------------------------"
+  echo " Open admin ports on ${GATEWAY:-gateway}: ${GW_OPEN:-none}"
+  echo "   (management reachable from a user drop is worth flagging)"
+  echo ""
+  echo "---- SEGMENTATION ----------------------------------------"
+  echo " $SEG_RESULT"
+  echo ""
+  echo "---- PER-VLAN EGRESS (tagged) ----------------------------"
+  if [ -s "$RUN/vlan_egress.txt" ]; then cat "$RUN/vlan_egress.txt"; else echo " (no tagged VLANs scanned)"; fi
+  echo ""
+  echo "---- RAW ARTIFACTS ---------------------------------------"
+  echo " egress_tcp.txt egress_udp53.txt http_probe.txt"
+  echo " gateway_mgmt.txt segmentation.txt (when SEG_TARGETS set)"
+  echo "=========================================================="
+} > "$REPORT"
+
+
+# ------------------------------ PHASE: DONE ---------------------------------
+glow FINISH
+CLEAR_SCREEN 2>/dev/null
+say "Seg/egress done"
+say "Egress: ${EG_ALLOW:-none}"
+ALERT "Seg/egress done. Allowed out: ${EG_ALLOW:-none}." 12 2>/dev/null
+exit 0

--- a/payloads/library/recon/segmentation_egress/payload.txt
+++ b/payloads/library/recon/segmentation_egress/payload.txt
@@ -27,16 +27,16 @@
 
 # ------------------------------- CONFIG -------------------------------------
 DHCP_WAIT_SECS=30
-EXT_IP="example.com"               # external probe target (stable, benign)
-EXT_HOST="example.com"         # external hostname for HTTP/TLS path tests
+EXT_IP="example.com"          # external probe target (stable, benign)
+EXT_HOST="example.com"        # external hostname for HTTP/TLS path tests
 EGRESS_PORTS="22,25,53,80,443,123,445,3389,1433,8080,8443"
-SEG_TARGETS=""                 # internal ranges/IPs to test reachability TO,
-                               # e.g. "10.10.10.0/24 10.20.0.1". Empty = gateway
-                               # mgmt surface only. Authorized scope ONLY.
+SEG_TARGETS=""                # internal ranges/IPs to test reachability TO,
+                              # e.g. "10.10.10.0/24 10.20.0.1". Empty = gateway
+                              # mgmt surface only. Authorized scope ONLY.
 SEG_PORTS="22,23,80,443,445,3389,8443"
 LOOT_BASE="/root/loot/segmentation"
 # VLAN-aware scanning: also tag onto and scan tagged VLANs seen on a trunk.
-SCAN_TAGGED_VLANS=0            # 1 = discover+scan tagged VLANs too. ACTIVE VLAN-
+SCAN_TAGGED_VLANS=0           # 1 = discover+scan tagged VLANs too. ACTIVE VLAN-
                               #     hopping; set 0 for client sites unless it is
                               #     authorized. No-op on a plain access port.
 VLAN_PROBE_IDS=""             # fallback VIDs if none are sniffed, e.g. "2 3 10"

--- a/payloads/library/recon/segmentation_egress/payload.txt
+++ b/payloads/library/recon/segmentation_egress/payload.txt
@@ -45,7 +45,6 @@ PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
 # ----------------------------------------------------------------------------
 
 # ============================ helpers =======================================
-say()  { SCREEN_WRITE "$*" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 # ============================================================================
 
@@ -82,7 +81,7 @@ run_over_vlans() {                              # run_over_vlans <cb> <native_ne
   vids=$(vlan_candidates)
   for vid in $vids; do
     ip link add link eth0 name "eth0.$vid" type vlan id "$vid" 2>/dev/null
-    ip link show "eth0.$vid" >/dev/null 2>&1 || { say "VLAN $vid: no 802.1Q"; continue; }
+    ip link show "eth0.$vid" >/dev/null 2>&1 || { SCREEN_WRITE "VLAN $vid: no 802.1Q"; continue; }
     ip link set "eth0.$vid" up 2>/dev/null
     udhcpc -i "eth0.$vid" -n -q -t 4 -T 3 >/dev/null 2>&1
     vline=$(ip addr show "eth0.$vid" 2>/dev/null | grep -oE 'inet [0-9.]+/[0-9]+' | head -1 | awk '{print $2}')
@@ -102,15 +101,15 @@ run_over_vlans() {                              # run_over_vlans <cb> <native_ne
 # ------------------------------ PHASE: SETUP --------------------------------
 LED SETUP
 CLEAR_SCREEN 2>/dev/null
-say "Segmentation + egress"
-if ! have nmap; then LED FAIL; say "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
+SCREEN_WRITE "Segmentation + egress"
+if ! have nmap; then LED FAIL; SCREEN_WRITE "nmap missing - abort"; ALERT "nmap not installed" 8 2>/dev/null; exit 1; fi
 RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
 mkdir -p "$RUN"; REPORT="$RUN/summary.txt"
 
 
 # --------------------------- PHASE: NETWORK UP ------------------------------
 LED SPECIAL
-say "DHCP lease (eth0)"
+SCREEN_WRITE "DHCP lease (eth0)"
 NETMODE DHCP_CLIENT 2>/dev/null
 WAIT_FOR_LINK 2>/dev/null            # framework: block until carrier is up (the race fix)
 # Bounded lease wait: WAIT_FOR_IP blocks forever, so keep our own timeout to fail
@@ -122,17 +121,17 @@ for _ in $(seq 1 "$DHCP_WAIT_SECS"); do
   sleep 1
 done
 if [ -z "$IP" ]; then
-  LED FAIL; say "No lease - 802.1X?"
+  LED FAIL; SCREEN_WRITE "No lease - 802.1X?"
   echo "FAILED: no DHCP lease on eth0 (NAC/802.1X, no DHCP, or dead drop)." > "$REPORT"
   ALERT "No DHCP lease - see loot" 8 2>/dev/null; exit 1
 fi
 GATEWAY=$(ip route 2>/dev/null | awk '/default/{print $3; exit}')
-say "IP $IP/$PREFIX"
+SCREEN_WRITE "IP $IP/$PREFIX"
 
 
 # ----------------------------- PHASE: EGRESS --------------------------------
 LED STAGE1
-say "Testing egress"
+SCREEN_WRITE "Testing egress"
 CREATE_SPINNER "Outbound TCP -> $EXT_IP"
 nmap -Pn --reason -T4 -p "$EGRESS_PORTS" "$EXT_IP" -oN "$RUN/egress_tcp.txt" >/dev/null 2>&1
 nmap -Pn -sU -p53 "$EXT_IP" -oN "$RUN/egress_udp53.txt" >/dev/null 2>&1
@@ -147,7 +146,7 @@ UDP53=$(awk '/^53\/udp/{print ($2=="open"||$2=="open|filtered")?"allowed":"block
 
 # -------------------------- PHASE: INTERNET PATH ----------------------------
 LED STAGE2
-say "Internet path"
+SCREEN_WRITE "Internet path"
 CREATE_SPINNER "HTTP/TLS path"
 BODY=""
 if have wget; then BODY=$(wget -q -O- --timeout=6 "http://$EXT_HOST" 2>/dev/null)
@@ -168,7 +167,7 @@ STOP_SPINNER
 
 # ------------------------- PHASE: GW MGMT + SEGMENTATION --------------------
 LED STAGE3
-say "Gateway mgmt"
+SCREEN_WRITE "Gateway mgmt"
 CREATE_SPINNER "Gateway admin ports"
 nmap -Pn -T4 -p22,23,80,443,8443 "$GATEWAY" -oN "$RUN/gateway_mgmt.txt" >/dev/null 2>&1
 STOP_SPINNER
@@ -177,7 +176,7 @@ GW_OPEN=$(awk '/^[0-9]+\/tcp[ \t]+open/{split($1,a,"/"); printf "%s/%s ", a[1], 
 SEG_RESULT="not tested (SEG_TARGETS empty)"
 if [ -n "$SEG_TARGETS" ]; then
   LED STAGE4
-  say "Segmentation probe"
+  SCREEN_WRITE "Segmentation probe"
   CREATE_SPINNER "Reaching SEG_TARGETS"
   # shellcheck disable=SC2086
   nmap -Pn -T4 -p "$SEG_PORTS" $SEG_TARGETS -oG "$RUN/segmentation.gnmap" -oN "$RUN/segmentation.txt" >/dev/null 2>&1
@@ -197,7 +196,7 @@ fi
 scan_one() {                                    # scan_one <iface> <cidr> <label>
   local iface=$1 cidr=$2 label=$3 gw egal gwopen
   [ "$label" = "access" ] && return
-  say "$label: egress + gw"
+  SCREEN_WRITE "$label: egress + gw"
   gw=$(ip route 2>/dev/null | awk -v d="$iface" '/default/ && $0 ~ ("dev "d){print $3; exit}')
   [ -z "$gw" ] && gw=$(echo "$cidr" | sed 's,0/.*,1,')
   nmap -Pn --reason -T4 -e "$iface" -p "$EGRESS_PORTS" "$EXT_IP" -oN "$RUN/egress_$label.txt" >/dev/null 2>&1
@@ -211,14 +210,14 @@ scan_one() {                                    # scan_one <iface> <cidr> <label
 }
 if [ "$SCAN_TAGGED_VLANS" = "1" ]; then
   LED STAGE5
-  say "Per-VLAN egress"
+  SCREEN_WRITE "Per-VLAN egress"
   run_over_vlans scan_one "$(network_cidr "$IP" "$PREFIX")"
 fi
 
 
 # --------------------------- PHASE: WRITE LOOT ------------------------------
 LED CLEANUP
-say "Writing loot"
+SCREEN_WRITE "Writing loot"
 {
   echo "=========================================================="
   echo " SHARK JACK DISPLAY - SEGMENTATION + EGRESS"
@@ -256,7 +255,7 @@ say "Writing loot"
 # ------------------------------ PHASE: DONE ---------------------------------
 LED FINISH
 CLEAR_SCREEN 2>/dev/null
-say "Seg/egress done"
-say "Egress: ${EG_ALLOW:-none}"
+SCREEN_WRITE "Seg/egress done"
+SCREEN_WRITE "Egress: ${EG_ALLOW:-none}"
 ALERT "Seg/egress done. Allowed out: ${EG_ALLOW:-none}." 12 2>/dev/null
 exit 0

--- a/payloads/library/recon/segmentation_egress/payload.txt
+++ b/payloads/library/recon/segmentation_egress/payload.txt
@@ -46,7 +46,6 @@ PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 # ============================================================================
@@ -135,7 +134,7 @@ say "IP $IP/$PREFIX"
 # ----------------------------- PHASE: EGRESS --------------------------------
 LED STAGE1
 say "Testing egress"
-spin_up "Outbound TCP -> $EXT_IP"
+CREATE_SPINNER "Outbound TCP -> $EXT_IP"
 nmap -Pn --reason -T4 -p "$EGRESS_PORTS" "$EXT_IP" -oN "$RUN/egress_tcp.txt" >/dev/null 2>&1
 nmap -Pn -sU -p53 "$EXT_IP" -oN "$RUN/egress_udp53.txt" >/dev/null 2>&1
 spin_down
@@ -150,7 +149,7 @@ UDP53=$(awk '/^53\/udp/{print ($2=="open"||$2=="open|filtered")?"allowed":"block
 # -------------------------- PHASE: INTERNET PATH ----------------------------
 LED STAGE2
 say "Internet path"
-spin_up "HTTP/TLS path"
+CREATE_SPINNER "HTTP/TLS path"
 BODY=""
 if have wget; then BODY=$(wget -q -O- --timeout=6 "http://$EXT_HOST" 2>/dev/null)
 elif have curl; then BODY=$(curl -s -m 6 "http://$EXT_HOST" 2>/dev/null); fi
@@ -171,7 +170,7 @@ spin_down
 # ------------------------- PHASE: GW MGMT + SEGMENTATION --------------------
 LED STAGE3
 say "Gateway mgmt"
-spin_up "Gateway admin ports"
+CREATE_SPINNER "Gateway admin ports"
 nmap -Pn -T4 -p22,23,80,443,8443 "$GATEWAY" -oN "$RUN/gateway_mgmt.txt" >/dev/null 2>&1
 spin_down
 GW_OPEN=$(awk '/^[0-9]+\/tcp[ \t]+open/{split($1,a,"/"); printf "%s/%s ", a[1], $3}' "$RUN/gateway_mgmt.txt" 2>/dev/null)
@@ -180,7 +179,7 @@ SEG_RESULT="not tested (SEG_TARGETS empty)"
 if [ -n "$SEG_TARGETS" ]; then
   LED STAGE4
   say "Segmentation probe"
-  spin_up "Reaching SEG_TARGETS"
+  CREATE_SPINNER "Reaching SEG_TARGETS"
   # shellcheck disable=SC2086
   nmap -Pn -T4 -p "$SEG_PORTS" $SEG_TARGETS -oG "$RUN/segmentation.gnmap" -oN "$RUN/segmentation.txt" >/dev/null 2>&1
   spin_down

--- a/payloads/library/recon/segmentation_egress/payload.txt
+++ b/payloads/library/recon/segmentation_egress/payload.txt
@@ -46,7 +46,6 @@ PASSIVE_VLAN_SECS=12          # passive 802.1Q listen window (needs tcpdump)
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 # ============================================================================
 
@@ -137,7 +136,7 @@ say "Testing egress"
 CREATE_SPINNER "Outbound TCP -> $EXT_IP"
 nmap -Pn --reason -T4 -p "$EGRESS_PORTS" "$EXT_IP" -oN "$RUN/egress_tcp.txt" >/dev/null 2>&1
 nmap -Pn -sU -p53 "$EXT_IP" -oN "$RUN/egress_udp53.txt" >/dev/null 2>&1
-spin_down
+STOP_SPINNER
 # open|closed => our SYN reached the internet (egress allowed); filtered => blocked.
 EG=$(awk '/^[0-9]+\/tcp/{ split($1,a,"/"); p=a[1]; if($2=="open"||$2=="closed") al=al" "p; else bl=bl" "p }
          END{ printf "ALLOWED:%s\nBLOCKED:%s\n", al, bl }' "$RUN/egress_tcp.txt" 2>/dev/null)
@@ -164,7 +163,7 @@ if have openssl; then
            | openssl x509 -noout -issuer 2>/dev/null | sed 's/^issuer= *//')
   [ -z "$ISSUER" ] && ISSUER="(no TLS handshake - egress blocked or proxied)"
 fi
-spin_down
+STOP_SPINNER
 
 
 # ------------------------- PHASE: GW MGMT + SEGMENTATION --------------------
@@ -172,7 +171,7 @@ LED STAGE3
 say "Gateway mgmt"
 CREATE_SPINNER "Gateway admin ports"
 nmap -Pn -T4 -p22,23,80,443,8443 "$GATEWAY" -oN "$RUN/gateway_mgmt.txt" >/dev/null 2>&1
-spin_down
+STOP_SPINNER
 GW_OPEN=$(awk '/^[0-9]+\/tcp[ \t]+open/{split($1,a,"/"); printf "%s/%s ", a[1], $3}' "$RUN/gateway_mgmt.txt" 2>/dev/null)
 
 SEG_RESULT="not tested (SEG_TARGETS empty)"
@@ -182,7 +181,7 @@ if [ -n "$SEG_TARGETS" ]; then
   CREATE_SPINNER "Reaching SEG_TARGETS"
   # shellcheck disable=SC2086
   nmap -Pn -T4 -p "$SEG_PORTS" $SEG_TARGETS -oG "$RUN/segmentation.gnmap" -oN "$RUN/segmentation.txt" >/dev/null 2>&1
-  spin_down
+  STOP_SPINNER
   SEG_HOSTS=$(awk -F'\t' '/Ports:/ && /open/{print $0}' "$RUN/segmentation.gnmap" 2>/dev/null \
               | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | sort -u | tr '\n' ' ')
   if [ -n "$SEG_HOSTS" ]; then SEG_RESULT="REACHABLE (segmentation gap): $SEG_HOSTS"

--- a/payloads/library/recon/voice_camera_discovery/README.md
+++ b/payloads/library/recon/voice_camera_discovery/README.md
@@ -12,8 +12,7 @@ this network, and where?" is the whole question.
 > networks you own or are contracted to assess, within the agreed scope and time
 > window, and do not retain third-party capture data beyond the engagement.
 > Nothing is exfiltrated: all output stays on-device under
-> `/root/loot/voice_camera/` until you retrieve it. See the Legal and Disclaimer
-> sections of the repository README.
+> `/root/loot/voice_camera/` until you retrieve it.
 
 ## How it identifies things
 

--- a/payloads/library/recon/voice_camera_discovery/README.md
+++ b/payloads/library/recon/voice_camera_discovery/README.md
@@ -1,0 +1,97 @@
+# Shark Jack Display - Voice & Camera Discovery
+
+Passively inventories the VoIP and physical-security estate on the segment it
+lands on, **sending nothing**. In one capture window it identifies IP phones,
+cameras and NVRs, and the voice VLAN the switch hands this port, then writes a
+leadership-ready inventory. Built for physical-security reviews, office moves,
+and M&A site surveys, the moments when "what cameras and phones are actually on
+this network, and where?" is the whole question.
+
+> **Authorized use only.** Passive capture only: no DHCP request, no probes, no
+> scans, which makes it safe to run on a live client network. Run only on
+> networks you own or are contracted to assess, within the agreed scope and time
+> window, and do not retain third-party capture data beyond the engagement.
+> Nothing is exfiltrated: all output stays on-device under
+> `/root/loot/voice_camera/` until you retrieve it. See the Legal and Disclaimer
+> sections of the repository README.
+
+## How it identifies things
+
+It does not trust any single source; it fuses passive signals and records the
+evidence behind every classification:
+
+| Device | Signals (strongest first) |
+|--------|---------------------------|
+| **Cameras / NVRs** | ONVIF **WS-Discovery** (UDP 3702), mDNS A/V services (`_onvif`, `_rtsp`, `_axis-video`, vendor types), MAC OUI |
+| **IP phones** | mDNS **SIP** services, MAC OUI (Polycom, Yealink, Cisco, Avaya, Mitel, Grandstream, Snom, ...), DHCP vendor class |
+| **Voice VLAN** | **LLDP-MED** Network Policy (Voice) and/or **CDP**, corroborated by the 802.1Q tag IDs seen on the wire |
+
+Each inventory row carries an **Evidence** column (e.g. `ONVIF/WS-Discovery, OUI:Axis`),
+so a high-confidence ONVIF hit reads differently from an OUI-only guess. A device
+that announces via ONVIF but never ARPs during the window is still listed (with an
+unknown MAC), so you do not miss a silent NVR.
+
+## Scope: what "the segment" means (read this)
+
+A single wired port only sees the **broadcast domain(s) it is in**. Multicast
+discovery (WS-Discovery, mDNS, SSDP) and ARP only reach you from the VLAN your
+port is on (or every tagged VLAN, if it is a trunk). So:
+
+- **Voice VLAN detection works even from a phone/data access port**, because the
+  switch advertises the voice VLAN to that port via LLDP-MED/CDP, and voice frames
+  are tagged (visible in the 802.1Q tag list).
+- **To inventory a dedicated camera VLAN, land on that VLAN or on a trunk.** From a
+  data-only access port you will see the phones/cameras sharing that VLAN, but not
+  devices isolated on a separate camera VLAN.
+
+The report states this scope in its header so the deliverable is honest about what
+it could and could not see.
+
+## Output (loot)
+
+`/root/loot/voice_camera/<UTC-timestamp>_<pid>/`:
+
+```
+summary.txt        <- voice VLAN + phone/camera inventory tables (read this first)
+capture.pcap       <- full passive capture (open in Wireshark)
+lldp.txt / cdp.txt <- neighbor + voice VLAN decode
+wsdiscovery.txt    <- ONVIF WS-Discovery (camera/NVR)
+mdns.txt / ssdp.txt <- service discovery
+dhcp.txt           <- DHCP option decode (hostnames, vendor classes)
+arp_hosts.tsv      <- passive host list (IP + MAC)
+phones.tsv / cameras.tsv <- the inventory tables (tab-separated, for import)
+```
+
+## Configuration (top of [`payload.txt`](payload.txt))
+
+| Knob | Default | Notes |
+|------|---------|-------|
+| `LISTEN_SECS` | `180` | capture window. LLDP/CDP announce every 30-60s and phones/cameras beacon periodically, so `>=120s` is wise; longer catches more |
+| `LOOT_BASE` | `/root/loot/voice_camera` | where loot lands |
+
+## Requirements
+
+- **`tcpdump`** (not on stock firmware): `opkg update && opkg install tcpdump`.
+  `nmap` is not used by this payload, it never scans.
+
+## LED / screen cues
+
+`SETUP` -> `SPECIAL` (listening, with a progress bar) -> `STAGE1` (decoding) ->
+`STAGE2` (classifying) -> `CLEANUP` (writing loot) -> `FINISH`. Red `FAIL` means
+`tcpdump` is not installed. The final `ALERT` carries the phone count, camera
+count, and the detected voice VLAN.
+
+## Notes
+
+- **Works on 802.1X / NAC ports**: it never requests an IP, so a port that will
+  not hand out a lease is no obstacle to discovery.
+- The OUI table is a curated convenience for well-known phone/camera vendors. The
+  device's `nmap-mac-prefixes` is authoritative for vendor strings, and protocol
+  evidence (ONVIF / mDNS / LLDP-MED) outranks OUI for classification. A vendor of
+  `-` with strong protocol evidence is still a confident hit.
+- Promiscuous mode is left on intentionally so multicast discovery frames arrive.
+- Like the passive listener, this brings `eth0` up without an address
+  (`ip link set eth0 up`) so it announces nothing. There is no passive/monitor
+  `NETMODE` on this device.
+- For the widest inventory, run a longer window and, where authorized, land on a
+  trunk so every VLAN's discovery traffic is visible in one pass.

--- a/payloads/library/recon/voice_camera_discovery/payload.txt
+++ b/payloads/library/recon/voice_camera_discovery/payload.txt
@@ -41,7 +41,6 @@ LOOT_BASE="/root/loot/voice_camera"
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-glow() { LED "$@" 2>/dev/null; }
 spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
@@ -87,12 +86,12 @@ oui_class() {
 
 
 # ------------------------------ PHASE: SETUP --------------------------------
-glow SETUP
+LED SETUP
 CLEAR_SCREEN 2>/dev/null
 say "Voice & Camera Discovery"
 
 if ! have tcpdump; then
-  glow FAIL
+  LED FAIL
   say "tcpdump missing"
   ALERT "Install tcpdump: opkg install tcpdump" 8 2>/dev/null
   exit 1
@@ -109,7 +108,7 @@ WAIT_FOR_LINK 2>/dev/null            # don't start the capture before carrier is
 
 
 # ---------------------------- PHASE: LISTEN ---------------------------------
-glow SPECIAL
+LED SPECIAL
 say "Listening ${LISTEN_SECS}s"
 CREATE_PROGRESS_BAR "Capturing traffic" 2>/dev/null
 # Promisc left ON (no -p) so multicast control/discovery frames arrive.
@@ -124,7 +123,7 @@ SET_PROGRESS 100 2>/dev/null
 
 
 # --------------------------- PHASE: DECODE ----------------------------------
-glow STAGE1
+LED STAGE1
 say "Decoding capture"
 
 # --- Switch neighbors: LLDP (0x88cc) + CDP (Cisco multicast) ---
@@ -187,7 +186,7 @@ spin_down
 
 
 # --------------------------- PHASE: CLASSIFY --------------------------------
-glow STAGE2
+LED STAGE2
 say "Classifying devices"
 
 mac_for() { awk -F'\t' -v ip="$1" '$1==ip{print $2; exit}' "$RUN/arp_hosts.tsv" 2>/dev/null; }
@@ -233,7 +232,7 @@ VOICE_SUMMARY="$VOICE_VLAN_LLDP"
 
 
 # --------------------------- PHASE: WRITE LOOT ------------------------------
-glow CLEANUP
+LED CLEANUP
 say "Writing loot"
 {
   echo "=========================================================="
@@ -295,7 +294,7 @@ say "Writing loot"
 
 
 # ------------------------------ PHASE: DONE ---------------------------------
-glow FINISH
+LED FINISH
 CLEAR_SCREEN 2>/dev/null
 say "Voice/Camera done"
 say "Phones: $NPHONE"

--- a/payloads/library/recon/voice_camera_discovery/payload.txt
+++ b/payloads/library/recon/voice_camera_discovery/payload.txt
@@ -5,6 +5,7 @@
 #  Target:      An authorized wired drop; ideally a phone/data port or a trunk.
 #  Category:    recon (passive)
 #  Version:     1.0
+#  Firmware:    Tested on Shark Jack Display 1.0.1
 # ----------------------------------------------------------------------------
 #  WHAT IT DOES
 #    Passively inventories the VoIP and physical-security estate on the segment

--- a/payloads/library/recon/voice_camera_discovery/payload.txt
+++ b/payloads/library/recon/voice_camera_discovery/payload.txt
@@ -40,7 +40,6 @@ LOOT_BASE="/root/loot/voice_camera"
 # ----------------------------------------------------------------------------
 
 # ============================ helpers =======================================
-say()  { SCREEN_WRITE "$*" 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
 # Lift an LLDP TLV value out of tcpdump -v output (value inline or next line).
@@ -86,11 +85,11 @@ oui_class() {
 # ------------------------------ PHASE: SETUP --------------------------------
 LED SETUP
 CLEAR_SCREEN 2>/dev/null
-say "Voice & Camera Discovery"
+SCREEN_WRITE "Voice & Camera Discovery"
 
 if ! have tcpdump; then
   LED FAIL
-  say "tcpdump missing"
+  SCREEN_WRITE "tcpdump missing"
   ALERT "Install tcpdump: opkg install tcpdump" 8 2>/dev/null
   exit 1
 fi
@@ -107,7 +106,7 @@ WAIT_FOR_LINK 2>/dev/null            # don't start the capture before carrier is
 
 # ---------------------------- PHASE: LISTEN ---------------------------------
 LED SPECIAL
-say "Listening ${LISTEN_SECS}s"
+SCREEN_WRITE "Listening ${LISTEN_SECS}s"
 CREATE_PROGRESS_BAR "Capturing traffic" 2>/dev/null
 # Promisc left ON (no -p) so multicast control/discovery frames arrive.
 tcpdump -i eth0 -s 0 -w "$PCAP" 2>/dev/null &
@@ -122,7 +121,7 @@ SET_PROGRESS 100 2>/dev/null
 
 # --------------------------- PHASE: DECODE ----------------------------------
 LED STAGE1
-say "Decoding capture"
+SCREEN_WRITE "Decoding capture"
 
 # --- Switch neighbors: LLDP (0x88cc) + CDP (Cisco multicast) ---
 CREATE_SPINNER "LLDP / CDP"
@@ -185,7 +184,7 @@ STOP_SPINNER
 
 # --------------------------- PHASE: CLASSIFY --------------------------------
 LED STAGE2
-say "Classifying devices"
+SCREEN_WRITE "Classifying devices"
 
 mac_for() { awk -F'\t' -v ip="$1" '$1==ip{print $2; exit}' "$RUN/arp_hosts.tsv" 2>/dev/null; }
 
@@ -231,7 +230,7 @@ VOICE_SUMMARY="$VOICE_VLAN_LLDP"
 
 # --------------------------- PHASE: WRITE LOOT ------------------------------
 LED CLEANUP
-say "Writing loot"
+SCREEN_WRITE "Writing loot"
 {
   echo "=========================================================="
   echo " SHARK JACK DISPLAY - VOICE & CAMERA DISCOVERY"
@@ -294,9 +293,9 @@ say "Writing loot"
 # ------------------------------ PHASE: DONE ---------------------------------
 LED FINISH
 CLEAR_SCREEN 2>/dev/null
-say "Voice/Camera done"
-say "Phones: $NPHONE"
-say "Cameras: $NCAM"
-say "Voice VLAN: $VOICE_SUMMARY"
+SCREEN_WRITE "Voice/Camera done"
+SCREEN_WRITE "Phones: $NPHONE"
+SCREEN_WRITE "Cameras: $NCAM"
+SCREEN_WRITE "Voice VLAN: $VOICE_SUMMARY"
 ALERT "Voice/Camera: $NPHONE phones, $NCAM cameras, voice VLAN $VOICE_SUMMARY" 12 2>/dev/null
 exit 0

--- a/payloads/library/recon/voice_camera_discovery/payload.txt
+++ b/payloads/library/recon/voice_camera_discovery/payload.txt
@@ -1,0 +1,304 @@
+#!/bin/bash
+# ============================================================================
+#  Title:       Voice & Camera Discovery (Shark Jack Display)
+#  Author:      Brent Mills
+#  Target:      An authorized wired drop; ideally a phone/data port or a trunk.
+#  Category:    recon (passive)
+#  Version:     1.0
+# ----------------------------------------------------------------------------
+#  WHAT IT DOES
+#    Passively inventories the VoIP and physical-security estate on the segment
+#    it lands on, sending nothing. In one capture window it identifies:
+#      - IP phones ......... by MAC OUI, mDNS SIP, DHCP vendor class.
+#      - Cameras / NVRs .... by WS-Discovery (ONVIF), mDNS A/V services, OUI.
+#      - Voice VLAN ........ the VLAN the switch advertises to this port via
+#                            LLDP-MED Network Policy and/or CDP, corroborated by
+#                            802.1Q tags seen on the wire.
+#    Then it writes a leadership-ready inventory. Built for physical-security
+#    reviews, office moves, and M&A site surveys.
+#
+#  WHY PASSIVE
+#    It only listens: no DHCP request, no probes, no scans. That makes it safe
+#    to run on a live client network and quiet enough to leave running. It also
+#    means it inventories the BROADCAST DOMAIN it can see (see scope note in the
+#    README): to inventory a separate camera VLAN, land on that VLAN or a trunk.
+#
+#  AUTHORIZATION
+#    Passive capture only, on networks you own or are contracted to assess,
+#    within the agreed scope/time window. Do not retain third-party capture data
+#    beyond the engagement. All output stays on-device in /root/loot.
+#
+#  REQUIRES tcpdump:  opkg update && opkg install tcpdump
+# ============================================================================
+
+# ------------------------------- CONFIG -------------------------------------
+LISTEN_SECS=180                 # capture window. LLDP/CDP announce every 30-60s
+                                # and phones/cameras beacon periodically, so
+                                # >=120s is wise; longer catches more.
+LOOT_BASE="/root/loot/voice_camera"
+# ----------------------------------------------------------------------------
+
+# ============================ helpers =======================================
+say()  { SCREEN_WRITE "$*" 2>/dev/null; }
+glow() { LED "$@" 2>/dev/null; }
+spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
+spin_down() { STOP_SPINNER 2>/dev/null; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Lift an LLDP TLV value out of tcpdump -v output (value inline or next line).
+lldp_field() {
+  awk -v lbl="$2" '
+    index($0,lbl) {
+      rest=substr($0,index($0,lbl)); val=""
+      if (match(rest,/: /)) val=substr(rest,RSTART+2)
+      if (val ~ /^[ \t]*$/) getline val
+      gsub(/^[ \t]+|[ \t]+$/,"",val); sub(/^Subtype[^:]*: /,"",val); print val; exit
+    }' "$1" 2>/dev/null
+}
+
+# Curated voice/video OUI table (first 3 octets). A convenience hint only: the
+# device's nmap-mac-prefixes table is authoritative for vendor strings, and
+# protocol evidence (ONVIF/mDNS/LLDP-MED) outranks OUI for classification.
+# Echoes "class|vendor"; class is phone, camera, or empty.
+oui_class() {
+  local p; p=$(printf '%s' "$1" | tr 'A-Z' 'a-z' | cut -c1-8)
+  case "$p" in
+    00:04:f2|64:16:7f|48:25:67|00:e0:db)                         echo "phone|Polycom" ;;
+    80:5e:c0|00:15:65|24:9a:d8|80:5e:0c|70:46:34)                echo "phone|Yealink" ;;
+    00:0e:08)                                                    echo "phone|Cisco/Sipura" ;;
+    00:04:0d|3c:3a:73|b4:b0:17|00:1b:4f|00:09:6e|2c:f4:c5)       echo "phone|Avaya" ;;
+    08:00:0f|00:10:e0)                                           echo "phone|Mitel" ;;
+    00:0b:82|c0:74:ad)                                           echo "phone|Grandstream" ;;
+    00:04:13)                                                    echo "phone|Snom" ;;
+    00:08:5d)                                                    echo "phone|Aastra" ;;
+    44:19:b6|c0:56:e3|4c:bd:8f|bc:ad:28|28:57:be|a4:14:37|54:c4:15|e0:ca:3c) echo "camera|Hikvision" ;;
+    3c:ef:8c|90:02:a9|14:a7:8b|08:ed:ed|e0:50:8b|bc:32:5f|4c:11:bf|a0:bd:1d)  echo "camera|Dahua" ;;
+    00:40:8c|ac:cc:8e|b8:a4:4f|e8:27:25)                         echo "camera|Axis" ;;
+    00:09:18|e4:30:22)                                           echo "camera|Hanwha" ;;
+    00:07:5f|00:1c:44)                                           echo "camera|Bosch" ;;
+    00:02:d1)                                                    echo "camera|Vivotek" ;;
+    48:ea:63)                                                    echo "camera|Uniview" ;;
+    00:03:c5)                                                    echo "camera|Mobotix" ;;
+    *)                                                           echo "|" ;;
+  esac
+}
+# ============================================================================
+
+
+# ------------------------------ PHASE: SETUP --------------------------------
+glow SETUP
+CLEAR_SCREEN 2>/dev/null
+say "Voice & Camera Discovery"
+
+if ! have tcpdump; then
+  glow FAIL
+  say "tcpdump missing"
+  ALERT "Install tcpdump: opkg install tcpdump" 8 2>/dev/null
+  exit 1
+fi
+
+RUN="$LOOT_BASE/$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo run)_$$"
+mkdir -p "$RUN"
+REPORT="$RUN/summary.txt"
+PCAP="$RUN/capture.pcap"
+
+# Link up, no IP: frames flow without us announcing an address.
+ip link set eth0 up 2>/dev/null
+WAIT_FOR_LINK 2>/dev/null            # don't start the capture before carrier is up
+
+
+# ---------------------------- PHASE: LISTEN ---------------------------------
+glow SPECIAL
+say "Listening ${LISTEN_SECS}s"
+CREATE_PROGRESS_BAR "Capturing traffic" 2>/dev/null
+# Promisc left ON (no -p) so multicast control/discovery frames arrive.
+tcpdump -i eth0 -s 0 -w "$PCAP" 2>/dev/null &
+TPID=$!
+for i in $(seq 1 "$LISTEN_SECS"); do
+  SET_PROGRESS $(( i * 100 / LISTEN_SECS )) 2>/dev/null
+  sleep 1
+done
+kill "$TPID" 2>/dev/null; wait "$TPID" 2>/dev/null
+SET_PROGRESS 100 2>/dev/null
+
+
+# --------------------------- PHASE: DECODE ----------------------------------
+glow STAGE1
+say "Decoding capture"
+
+# --- Switch neighbors: LLDP (0x88cc) + CDP (Cisco multicast) ---
+spin_up "LLDP / CDP"
+tcpdump -nn -v -r "$PCAP" 'ether proto 0x88cc' 2>/dev/null > "$RUN/lldp.txt"
+tcpdump -nn -v -r "$PCAP" 'ether host 01:00:0c:cc:cc:cc' 2>/dev/null > "$RUN/cdp.txt"
+L_NAME=$(lldp_field "$RUN/lldp.txt" 'System Name TLV')
+L_PORT=$(lldp_field "$RUN/lldp.txt" 'Port ID TLV')
+C_DEV=$(grep -i 'Device-ID' "$RUN/cdp.txt" 2>/dev/null | head -1 | sed "s/.*: '//; s/'.*//")
+spin_down
+
+# --- Voice VLAN: LLDP-MED Network Policy (Voice) and/or CDP, then 802.1Q tags ---
+# tcpdump's exact wording varies by version, so match "voice" lines and pull the
+# VLAN number near them; keep raw lldp.txt/cdp.txt for the authoritative read.
+VOICE_VLAN_LLDP=$(grep -iE 'voice' "$RUN/lldp.txt" 2>/dev/null | grep -oiE 'vlan[^0-9]{0,4}[0-9]+' | grep -oE '[0-9]+' | sort -un | tr '\n' ' ')
+VOICE_VLAN_CDP=$(grep -iE 'VoIP VLAN|Voice VLAN|Appliance VLAN' "$RUN/cdp.txt" 2>/dev/null | grep -oE '[0-9]+' | sort -un | tr '\n' ' ')
+TAGGED_VLANS=$(tcpdump -e -nn -r "$PCAP" vlan 2>/dev/null | grep -oE 'vlan [0-9]+' | awk '{print $2}' | sort -un | tr '\n' ' ')
+[ -z "$VOICE_VLAN_LLDP" ] && VOICE_VLAN_LLDP="-"
+[ -z "$VOICE_VLAN_CDP" ]  && VOICE_VLAN_CDP="-"
+[ -z "$TAGGED_VLANS" ]    && TAGGED_VLANS="-"
+
+# --- ONVIF / WS-Discovery (UDP 3702): the strongest camera/NVR signal ---
+spin_up "ONVIF / mDNS"
+tcpdump -nn -A -r "$PCAP" 'udp port 3702' 2>/dev/null > "$RUN/wsdiscovery.txt"
+tcpdump -nn -r "$PCAP" 'udp port 3702' 2>/dev/null \
+  | sed -nE 's/^IP ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\.[0-9]+ >.*/\1/p' \
+  | grep -vE '^(239|224)\.' | sort -u > "$RUN/wsd_ips.txt"
+
+# --- mDNS (UDP 5353): A/V service IPs (camera) and SIP service IPs (phone) ---
+tcpdump -nn -A -r "$PCAP" 'udp port 5353' 2>/dev/null > "$RUN/mdns.txt"
+grep -iE '_axis-video|_onvif|_rtsp|_dahua|_hikvision|_amcrest|_uniview|_csco-sb|_nvstream' "$RUN/mdns.txt" 2>/dev/null \
+  | sed -nE 's/^IP ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\.5353 >.*/\1/p' | sort -u > "$RUN/mdns_cam_ips.txt"
+grep -iE '_sip\.|_sips|_h323|_ciscortp|_cisco' "$RUN/mdns.txt" 2>/dev/null \
+  | sed -nE 's/^IP ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\.5353 >.*/\1/p' | sort -u > "$RUN/mdns_sip_ips.txt"
+grep -oE '[A-Za-z0-9._-]+\.local' "$RUN/mdns.txt" 2>/dev/null | sort -u > "$RUN/mdns_names.txt"
+
+# --- SSDP / UPnP (UDP 1900): supplementary device hints ---
+tcpdump -nn -A -r "$PCAP" 'udp port 1900' 2>/dev/null | grep -iE '^(SERVER|LOCATION|ST|USN):' | sort -u > "$RUN/ssdp.txt"
+spin_down
+
+# --- DHCP (67/68): vendor class (option 60) + hostnames as name enrichment ---
+spin_up "Passive ARP / DHCP"
+tcpdump -nn -e -vv -r "$PCAP" '(udp port 67 or udp port 68)' 2>/dev/null > "$RUN/dhcp.txt"
+{
+  grep -i 'Hostname Option' "$RUN/dhcp.txt" 2>/dev/null | sed 's/.*Hostname Option[^:]*: *//; s/^"//; s/".*$//'
+} | sort -u > "$RUN/dhcp_hostnames.txt"
+grep -i 'Option 60' "$RUN/dhcp.txt" 2>/dev/null | sed 's/.*Option 60[^:]*: *//; s/^"//; s/".*$//' | sort -u > "$RUN/dhcp_vendorclass.txt"
+
+# --- Passive ARP -> master host list (IP + MAC), no probes sent by us ---
+tcpdump -nn -e -r "$PCAP" arp 2>/dev/null | awk '
+  {
+    mac=""
+    for (i=1;i<=NF;i++) if (mac=="" && $i ~ /^([0-9a-f]{2}:){5}[0-9a-f]{2}$/) mac=$i
+    for (i=1;i<=NF;i++) {
+      if ($i=="tell")  { ip=$(i+1);   gsub(/[,:]$/,"",ip);   if (ip ~ /^[0-9]+\./ && mac!="") print ip"\t"mac }
+      if ($i=="is-at") { ip=$(i-1); gsub(/[,:]$/,"",ip); m=$(i+1); gsub(/[,:]$/,"",m); if (ip ~ /^[0-9]+\./ && m ~ /:/) print ip"\t"m }
+    }
+  }' | sort -u > "$RUN/arp_hosts.tsv"
+spin_down
+
+
+# --------------------------- PHASE: CLASSIFY --------------------------------
+glow STAGE2
+say "Classifying devices"
+
+mac_for() { awk -F'\t' -v ip="$1" '$1==ip{print $2; exit}' "$RUN/arp_hosts.tsv" 2>/dev/null; }
+
+# Candidate IPs = everything we have any handle on (ARP + ONVIF + mDNS).
+{ cut -f1 "$RUN/arp_hosts.tsv" 2>/dev/null
+  cat "$RUN/wsd_ips.txt" "$RUN/mdns_cam_ips.txt" "$RUN/mdns_sip_ips.txt" 2>/dev/null
+} | grep -E '^[0-9]+\.' | sort -u > "$RUN/candidates.txt"
+
+: > "$RUN/phones.tsv"
+: > "$RUN/cameras.tsv"
+OTHER=0
+
+while read -r ip; do
+  [ -z "$ip" ] && continue
+  mac=$(mac_for "$ip"); [ -z "$mac" ] && mac="-"
+  oc=$(oui_class "$mac"); ocls=${oc%%|*}; oven=${oc#*|}; [ -z "$oven" ] && oven="-"
+
+  cam_ev=""
+  grep -qxF "$ip" "$RUN/wsd_ips.txt"      2>/dev/null && cam_ev="ONVIF/WS-Discovery"
+  grep -qxF "$ip" "$RUN/mdns_cam_ips.txt" 2>/dev/null && cam_ev="${cam_ev:+$cam_ev, }mDNS A/V"
+  [ "$ocls" = "camera" ] && cam_ev="${cam_ev:+$cam_ev, }OUI:$oven"
+
+  phone_ev=""
+  grep -qxF "$ip" "$RUN/mdns_sip_ips.txt" 2>/dev/null && phone_ev="mDNS SIP"
+  [ "$ocls" = "phone" ] && phone_ev="${phone_ev:+$phone_ev, }OUI:$oven"
+
+  if [ -n "$cam_ev" ]; then
+    printf '%s\t%s\t%s\t%s\n' "$ip" "$mac" "$oven" "$cam_ev" >> "$RUN/cameras.tsv"
+  elif [ -n "$phone_ev" ]; then
+    printf '%s\t%s\t%s\t%s\n' "$ip" "$mac" "$oven" "$phone_ev" >> "$RUN/phones.tsv"
+  else
+    OTHER=$((OTHER + 1))
+  fi
+done < "$RUN/candidates.txt"
+
+NPHONE=$(wc -l < "$RUN/phones.tsv" 2>/dev/null | tr -d ' '); [ -z "$NPHONE" ] && NPHONE=0
+NCAM=$(wc -l < "$RUN/cameras.tsv" 2>/dev/null | tr -d ' '); [ -z "$NCAM" ] && NCAM=0
+
+VOICE_SUMMARY="$VOICE_VLAN_LLDP"
+[ "$VOICE_SUMMARY" = "-" ] && VOICE_SUMMARY="$VOICE_VLAN_CDP"
+[ "$VOICE_SUMMARY" = "-" ] && VOICE_SUMMARY="none advertised"
+
+
+# --------------------------- PHASE: WRITE LOOT ------------------------------
+glow CLEANUP
+say "Writing loot"
+{
+  echo "=========================================================="
+  echo " SHARK JACK DISPLAY - VOICE & CAMERA DISCOVERY"
+  echo "=========================================================="
+  echo " Run time : $(date -u '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null)"
+  echo " Window   : ${LISTEN_SECS}s passive capture on eth0"
+  echo " Scope    : the broadcast domain(s) visible from this port"
+  echo ""
+  echo "---- VOICE VLAN ------------------------------------------"
+  echo " LLDP-MED voice VLAN : $VOICE_VLAN_LLDP"
+  echo " CDP voice VLAN      : $VOICE_VLAN_CDP"
+  echo " 802.1Q tags seen    : $TAGGED_VLANS"
+  echo " Note: the voice VLAN is what the switch advertises to THIS port."
+  echo "       Tagged VLANs corroborate it (voice frames are tagged)."
+  echo ""
+  echo "---- SWITCH / PORT (for locating the drop) ---------------"
+  echo " LLDP system name : ${L_NAME:--}"
+  echo " LLDP our port    : ${L_PORT:--}"
+  echo " CDP device       : ${C_DEV:--}"
+  echo ""
+  echo "---- IP PHONES ($NPHONE) ---------------------------------"
+  if [ "$NPHONE" -gt 0 ]; then
+    printf " %-15s %-17s %-12s %s\n" "IP" "MAC" "Vendor" "Evidence"
+    awk -F'\t' '{printf " %-15s %-17s %-12s %s\n",$1,$2,$3,$4}' "$RUN/phones.tsv"
+  else
+    echo " (none identified in the visible broadcast domain)"
+  fi
+  echo ""
+  echo "---- CAMERAS / NVRs ($NCAM) ------------------------------"
+  if [ "$NCAM" -gt 0 ]; then
+    printf " %-15s %-17s %-12s %s\n" "IP" "MAC" "Vendor" "Evidence"
+    awk -F'\t' '{printf " %-15s %-17s %-12s %s\n",$1,$2,$3,$4}' "$RUN/cameras.tsv"
+  else
+    echo " (none identified in the visible broadcast domain)"
+  fi
+  echo ""
+  echo "---- OTHER HOSTS SEEN ------------------------------------"
+  echo " $OTHER non-voice/video host(s) observed (not detailed here)."
+  echo ""
+  echo "---- DHCP-OBSERVED NAMES / VENDOR CLASSES ----------------"
+  if [ -s "$RUN/dhcp_hostnames.txt" ] || [ -s "$RUN/dhcp_vendorclass.txt" ]; then
+    [ -s "$RUN/dhcp_hostnames.txt" ]   && { echo " Hostnames:";      sed 's/^/   /' "$RUN/dhcp_hostnames.txt"; }
+    [ -s "$RUN/dhcp_vendorclass.txt" ] && { echo " Vendor classes:"; sed 's/^/   /' "$RUN/dhcp_vendorclass.txt"; }
+  else
+    echo " (no DHCP broadcasts captured in window)"
+  fi
+  echo ""
+  echo "---- RAW ARTIFACTS ---------------------------------------"
+  echo " capture.pcap          - full passive capture (open in Wireshark)"
+  echo " lldp.txt / cdp.txt    - neighbor + voice VLAN decode"
+  echo " wsdiscovery.txt       - ONVIF WS-Discovery (camera/NVR)"
+  echo " mdns.txt / ssdp.txt   - service discovery"
+  echo " dhcp.txt              - DHCP option decode"
+  echo " arp_hosts.tsv         - passive host list (IP + MAC)"
+  echo " phones.tsv / cameras.tsv - the inventory tables"
+  echo "=========================================================="
+} > "$REPORT"
+
+
+# ------------------------------ PHASE: DONE ---------------------------------
+glow FINISH
+CLEAR_SCREEN 2>/dev/null
+say "Voice/Camera done"
+say "Phones: $NPHONE"
+say "Cameras: $NCAM"
+say "Voice VLAN: $VOICE_SUMMARY"
+ALERT "Voice/Camera: $NPHONE phones, $NCAM cameras, voice VLAN $VOICE_SUMMARY" 12 2>/dev/null
+exit 0

--- a/payloads/library/recon/voice_camera_discovery/payload.txt
+++ b/payloads/library/recon/voice_camera_discovery/payload.txt
@@ -41,7 +41,6 @@ LOOT_BASE="/root/loot/voice_camera"
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-spin_up()   { CREATE_SPINNER "$*" 2>/dev/null; }
 spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
@@ -127,7 +126,7 @@ LED STAGE1
 say "Decoding capture"
 
 # --- Switch neighbors: LLDP (0x88cc) + CDP (Cisco multicast) ---
-spin_up "LLDP / CDP"
+CREATE_SPINNER "LLDP / CDP"
 tcpdump -nn -v -r "$PCAP" 'ether proto 0x88cc' 2>/dev/null > "$RUN/lldp.txt"
 tcpdump -nn -v -r "$PCAP" 'ether host 01:00:0c:cc:cc:cc' 2>/dev/null > "$RUN/cdp.txt"
 L_NAME=$(lldp_field "$RUN/lldp.txt" 'System Name TLV')
@@ -146,7 +145,7 @@ TAGGED_VLANS=$(tcpdump -e -nn -r "$PCAP" vlan 2>/dev/null | grep -oE 'vlan [0-9]
 [ -z "$TAGGED_VLANS" ]    && TAGGED_VLANS="-"
 
 # --- ONVIF / WS-Discovery (UDP 3702): the strongest camera/NVR signal ---
-spin_up "ONVIF / mDNS"
+CREATE_SPINNER "ONVIF / mDNS"
 tcpdump -nn -A -r "$PCAP" 'udp port 3702' 2>/dev/null > "$RUN/wsdiscovery.txt"
 tcpdump -nn -r "$PCAP" 'udp port 3702' 2>/dev/null \
   | sed -nE 's/^IP ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)\.[0-9]+ >.*/\1/p' \
@@ -165,7 +164,7 @@ tcpdump -nn -A -r "$PCAP" 'udp port 1900' 2>/dev/null | grep -iE '^(SERVER|LOCAT
 spin_down
 
 # --- DHCP (67/68): vendor class (option 60) + hostnames as name enrichment ---
-spin_up "Passive ARP / DHCP"
+CREATE_SPINNER "Passive ARP / DHCP"
 tcpdump -nn -e -vv -r "$PCAP" '(udp port 67 or udp port 68)' 2>/dev/null > "$RUN/dhcp.txt"
 {
   grep -i 'Hostname Option' "$RUN/dhcp.txt" 2>/dev/null | sed 's/.*Hostname Option[^:]*: *//; s/^"//; s/".*$//'

--- a/payloads/library/recon/voice_camera_discovery/payload.txt
+++ b/payloads/library/recon/voice_camera_discovery/payload.txt
@@ -41,7 +41,6 @@ LOOT_BASE="/root/loot/voice_camera"
 
 # ============================ helpers =======================================
 say()  { SCREEN_WRITE "$*" 2>/dev/null; }
-spin_down() { STOP_SPINNER 2>/dev/null; }
 have() { command -v "$1" >/dev/null 2>&1; }
 
 # Lift an LLDP TLV value out of tcpdump -v output (value inline or next line).
@@ -132,7 +131,7 @@ tcpdump -nn -v -r "$PCAP" 'ether host 01:00:0c:cc:cc:cc' 2>/dev/null > "$RUN/cdp
 L_NAME=$(lldp_field "$RUN/lldp.txt" 'System Name TLV')
 L_PORT=$(lldp_field "$RUN/lldp.txt" 'Port ID TLV')
 C_DEV=$(grep -i 'Device-ID' "$RUN/cdp.txt" 2>/dev/null | head -1 | sed "s/.*: '//; s/'.*//")
-spin_down
+STOP_SPINNER
 
 # --- Voice VLAN: LLDP-MED Network Policy (Voice) and/or CDP, then 802.1Q tags ---
 # tcpdump's exact wording varies by version, so match "voice" lines and pull the
@@ -161,7 +160,7 @@ grep -oE '[A-Za-z0-9._-]+\.local' "$RUN/mdns.txt" 2>/dev/null | sort -u > "$RUN/
 
 # --- SSDP / UPnP (UDP 1900): supplementary device hints ---
 tcpdump -nn -A -r "$PCAP" 'udp port 1900' 2>/dev/null | grep -iE '^(SERVER|LOCATION|ST|USN):' | sort -u > "$RUN/ssdp.txt"
-spin_down
+STOP_SPINNER
 
 # --- DHCP (67/68): vendor class (option 60) + hostnames as name enrichment ---
 CREATE_SPINNER "Passive ARP / DHCP"
@@ -181,7 +180,7 @@ tcpdump -nn -e -r "$PCAP" arp 2>/dev/null | awk '
       if ($i=="is-at") { ip=$(i-1); gsub(/[,:]$/,"",ip); m=$(i+1); gsub(/[,:]$/,"",m); if (ip ~ /^[0-9]+\./ && m ~ /:/) print ip"\t"m }
     }
   }' | sort -u > "$RUN/arp_hosts.tsv"
-spin_down
+STOP_SPINNER
 
 
 # --------------------------- PHASE: CLASSIFY --------------------------------

--- a/tools/deploy-shark/.gitignore
+++ b/tools/deploy-shark/.gitignore
@@ -1,0 +1,3 @@
+# User deploy config: holds site-specific IPs / hostnames / overrides.
+# Keep your real config here; it must not be committed.
+shark.conf

--- a/tools/deploy-shark/README.md
+++ b/tools/deploy-shark/README.md
@@ -1,0 +1,103 @@
+# deploy-shark
+
+Provision a Shark Jack Display from this repository, driven by a config file.
+
+A firmware update wipes the device overlay, taking your payloads and the nmap
+OUI database with it. `deploy-shark.sh` puts them back: it reads a `shark.conf`
+that lists exactly which payloads you want, applies any per-payload config
+overrides you define, and pushes the result onto the device.
+
+> **Note on repo layout.** The contribution guidelines ask not to create new
+> top-level directories. This is a deploy *tool*, not a payload, so a `tools/`
+> directory fits it better than the payload tree. Flagged for Darren.
+
+## Quick start
+
+```sh
+./deploy-shark.sh --init        # write a starter shark.conf next to the script
+$EDITOR shark.conf              # choose payloads + set overrides
+./deploy-shark.sh --dry-run     # render + validate; contacts no device
+./deploy-shark.sh               # provision (prompts for IP + root password)
+```
+
+## Flags
+
+| Flag | Effect |
+|------|--------|
+| `-h`, `--help` | Full usage. |
+| `--init [FILE]` | Write a starter config (default `shark.conf`). Won't overwrite without `--force`. |
+| `--config FILE` | Use a config other than the default. |
+| `--dry-run` | Render payloads with overrides applied and report what *would* be pushed. No device contact, no prompts. |
+| `--no-oui` | Skip installing the nmap MAC/OUI database. |
+| `--force` | Let `--init` overwrite an existing config. |
+
+## Config format
+
+`shark.conf` is sectioned, one section per payload to load. Section names are the
+payload's directory under [`payloads/library/`](../../payloads/library/) (the
+script finds the category for you).
+
+```ini
+[options]
+shark_ip = 172.16.24.1          # default device IP (password is always prompted)
+install_oui_db = yes            # yes/no
+
+[port_id_beacon]                # loaded unchanged
+
+[jack_survey]
+EXPECTED_SWITCH="" --> EXPECTED_SWITCH="MDF-SW-01"
+EXPECTED_VLAN="" --> EXPECTED_VLAN="20"
+
+[remote_debug_bridge]
+JUMP_HOST="X.X.X.X" --> JUMP_HOST="203.0.113.10"
+JUMP_USER="sharkdebug" --> JUMP_USER="bridge"
+```
+
+### Overrides: `FIND --> REPLACE`
+
+Each override line is a **literal** find-and-replace applied to that payload's
+`payload.txt` before it is pushed. The `FIND` side must match the line in the
+payload's CONFIG block **exactly** (copy it straight from the payload), including
+the quotes. Replacement is literal (no regex), so special characters are safe.
+
+If a `FIND` string isn't present in the payload, the override is **skipped with a
+loud warning** rather than silently doing nothing, so a typo or an upstream
+change to a config line can't quietly leave you with the default value. Use
+`--dry-run` to see exactly which overrides applied before touching a device.
+
+## What gets pushed
+
+For each configured payload the script:
+
+1. Resolves `<name>` to `payloads/library/<category>/<name>/payload.txt`.
+2. Applies that section's overrides to a temporary copy.
+3. Pushes it as `/root/library/my_payloads/<name>/payload.txt`.
+
+Then it installs the nmap OUI database (unless `--no-oui` or `install_oui_db =
+no`), which several recon payloads use for vendor lookups.
+
+## Files
+
+| File | Tracked? | Purpose |
+|------|----------|---------|
+| `deploy-shark.sh` | yes | the tool |
+| `shark.conf.example` | yes | the documented template (also produced by `--init`) |
+| `shark.conf` | **no** (gitignored) | your real config: site IPs, hostnames, overrides |
+| `.gitignore` | yes | ignores `shark.conf` |
+
+`shark.conf` is gitignored on purpose: it holds deployment-specific values
+(jump-host IPs, expected switch names, etc.) that should not land in the repo.
+
+## Requirements
+
+- `bash`, `ssh`/`scp`, `curl`, `awk` (all standard on macOS/Linux).
+- Optional: `sshpass` so the password is entered once
+  (`brew install hudochenkov/sshpass/sshpass`). Without it, the script opens one
+  shared SSH connection and prompts a single time.
+
+## Auth / host keys
+
+A freshly-updated Shark presents a new host key, so the script disables strict
+host-key checking for the connection. That is appropriate for a device you
+control on a local link; do not reuse these options against arbitrary hosts. The
+root password is only ever prompted, never read from the config file.

--- a/tools/deploy-shark/deploy-shark.sh
+++ b/tools/deploy-shark/deploy-shark.sh
@@ -1,0 +1,360 @@
+#!/usr/bin/env bash
+# ============================================================================
+#  deploy-shark.sh - provision a Shark Jack Display from a repo + config file
+# ----------------------------------------------------------------------------
+#  A firmware update wipes the overlay (your payloads and the nmap OUI database
+#  go with it). Run this afterward to push a chosen set of payloads from THIS
+#  repository onto the device, applying any per-payload config overrides you
+#  define in a config file.
+#
+#  Unlike a blind "push everything", you list exactly which payloads you want in
+#  shark.conf and, under each, optional find-and-replace overrides applied to
+#  that payload's payload.txt before it is sent (so your jump host IP, expected
+#  switch names, etc. are baked in per deployment).
+#
+#  Quick start:
+#    ./deploy-shark.sh --init          # write a starter shark.conf
+#    $EDITOR shark.conf                # pick payloads + set overrides
+#    ./deploy-shark.sh --dry-run       # render + validate, touch no device
+#    ./deploy-shark.sh                 # provision the device
+#
+#  Run ./deploy-shark.sh --help for full usage.
+# ============================================================================
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+PAYLOAD_LIBRARY="$REPO_ROOT/payloads/library"
+DEFAULT_CONFIG="$SCRIPT_DIR/shark.conf"
+PREFIX_URL="https://raw.githubusercontent.com/nmap/nmap/master/nmap-mac-prefixes"
+DEFAULT_IP="172.16.24.1"        # Shark Jack arming-mode address
+
+# ---- logging (all to stderr so function stdout stays clean) ----------------
+info() { printf '%s\n' "$*" >&2; }
+warn() { printf '[!] %s\n' "$*" >&2; }
+die()  { printf '[x] %s\n' "$*" >&2; exit 1; }
+
+# ---- usage -----------------------------------------------------------------
+usage() {
+  cat <<EOF
+deploy-shark.sh - provision a Shark Jack Display from this repo + a config file
+
+USAGE
+  ./deploy-shark.sh [options]
+
+OPTIONS
+  -h, --help          Show this help and exit.
+  --init [FILE]       Write a starter config (template) and exit. Default
+                      target is shark.conf next to this script. Refuses to
+                      overwrite unless --force is given.
+  --config FILE       Use FILE instead of the default ($DEFAULT_CONFIG).
+  --dry-run           Render payloads with their overrides applied and report
+                      what WOULD be pushed. Touches no device, asks for nothing.
+  --no-oui            Skip installing the nmap MAC/OUI database.
+  --force             Allow --init to overwrite an existing config.
+
+CONFIG FILE (shark.conf)
+  Sectioned, one section per payload to load. Create one with --init.
+
+    [options]                          # optional global settings
+    shark_ip = 172.16.24.1             # default device IP (password is always
+                                       #   prompted, never stored)
+    install_oui_db = yes               # yes/no
+
+    [payload_name]                     # the payload's dir under payloads/library/
+      FIND --> REPLACE                 # optional literal find/replace applied to
+                                       #   this payload's payload.txt before push.
+                                       #   FIND must match the line EXACTLY.
+
+  A payload section with no FIND --> REPLACE lines is pushed unchanged. Lines
+  starting with # are comments. shark.conf is gitignored: keep your real IPs,
+  hostnames, and overrides there.
+
+WHAT IT DOES
+  1. Reads the config and resolves each named payload under payloads/library/.
+  2. Applies each payload's overrides to a temporary copy (warns loudly if a
+     FIND string is not present, so a typo cannot silently no-op).
+  3. Pushes each as /root/library/my_payloads/<name>/payload.txt.
+  4. Installs the nmap OUI database (unless --no-oui).
+
+AUTH
+  Uses sshpass if installed (password entered once). Otherwise falls back to a
+  single shared SSH connection that prompts once.
+    macOS: brew install hudochenkov/sshpass/sshpass
+EOF
+}
+
+# ---- template config (used by --init and shipped as shark.conf.example) -----
+template_config() {
+  cat <<'EOF'
+# ============================================================================
+#  shark.conf - deploy configuration for deploy-shark.sh
+# ----------------------------------------------------------------------------
+#  Pick which payloads to load onto the Shark Jack Display, and optionally
+#  override config values inside each payload before it is pushed.
+#
+#  FORMAT
+#    [options]                         global settings (optional)
+#      shark_ip = 172.16.24.1          default device IP (password is prompted)
+#      install_oui_db = yes            install the nmap OUI database (yes/no)
+#
+#    [payload_name]                    one section per payload to load. The name
+#                                      is the payload's directory under
+#                                      payloads/library/<category>/.
+#      FIND --> REPLACE                optional. Literal find-and-replace applied
+#                                      to that payload's payload.txt before it is
+#                                      pushed. FIND must match the line EXACTLY
+#                                      (copy it from the payload's CONFIG block).
+#
+#  A payload section with no FIND --> REPLACE lines is loaded unchanged.
+#  Lines starting with # are comments. This file is gitignored: keep your real
+#  IPs / hostnames / secrets here.
+# ============================================================================
+
+[options]
+shark_ip = 172.16.24.1
+install_oui_db = yes
+
+# --- Load the port-ID beacon, unchanged ---
+[port_id_beacon]
+
+# --- Load jack_survey, pre-filled with the drop you expect ---
+[jack_survey]
+EXPECTED_SWITCH="" --> EXPECTED_SWITCH="MDF-SW-01"
+EXPECTED_VLAN="" --> EXPECTED_VLAN="20"
+
+# --- Load the remote debug bridge, pointed at your jump host ---
+[remote_debug_bridge]
+JUMP_HOST="X.X.X.X" --> JUMP_HOST="203.0.113.10"
+JUMP_USER="sharkdebug" --> JUMP_USER="bridge"
+EOF
+}
+
+# ---- config parsing helpers (awk; bash 3.2 safe; tolerate CRLF) ------------
+# List payload section names in file order (excludes [options]).
+list_payloads() {
+  awk '
+    { sub(/\r$/,"") }
+    /^[[:space:]]*\[.*\][[:space:]]*$/ {
+      s=$0; gsub(/^[[:space:]]*\[|\][[:space:]]*$/,"",s)
+      if (s != "options" && s != "") print s
+    }
+  ' "$CONFIG"
+}
+
+# Print the FIND --> REPLACE lines belonging to one payload section.
+overrides_for() {
+  awk -v sec="$1" '
+    { sub(/\r$/,"") }
+    /^[[:space:]]*\[.*\][[:space:]]*$/ {
+      s=$0; gsub(/^[[:space:]]*\[|\][[:space:]]*$/,"",s); cur=s; next
+    }
+    cur==sec {
+      line=$0; sub(/^[[:space:]]+/,"",line); sub(/[[:space:]]+$/,"",line)
+      if (line=="" || line ~ /^#/) next
+      print line
+    }
+  ' "$CONFIG"
+}
+
+# Read a key from the [options] section.
+get_option() {
+  awk -v key="$1" '
+    { sub(/\r$/,"") }
+    /^[[:space:]]*\[.*\][[:space:]]*$/ {
+      s=$0; gsub(/^[[:space:]]*\[|\][[:space:]]*$/,"",s); cur=s; next
+    }
+    cur=="options" {
+      line=$0; sub(/^[[:space:]]+/,"",line); sub(/[[:space:]]+$/,"",line)
+      if (line=="" || line ~ /^#/) next
+      n=index(line,"="); if (n==0) next
+      k=substr(line,1,n-1); v=substr(line,n+1)
+      gsub(/[[:space:]]+$/,"",k); gsub(/^[[:space:]]+/,"",k)
+      gsub(/^[[:space:]]+/,"",v); gsub(/[[:space:]]+$/,"",v)
+      if (k==key) { print v; exit }
+    }
+  ' "$CONFIG"
+}
+
+# Literal (non-regex) global find/replace on a file, to stdout.
+apply_override() {
+  awk -v find="$2" -v repl="$3" '
+    { sub(/\r$/,"")
+      out=""; rest=$0
+      while ((p=index(rest,find))>0) { out=out substr(rest,1,p-1) repl; rest=substr(rest,p+length(find)) }
+      print out rest }
+  ' "$1"
+}
+
+# Resolve a payload name to its payload.txt under payloads/library/<cat>/<name>/.
+resolve_payload() {  # echoes path on success, empty on failure
+  local name="$1" matches=()
+  shopt -s nullglob
+  matches=( "$PAYLOAD_LIBRARY"/*/"$name"/payload.txt )
+  shopt -u nullglob
+  [ ${#matches[@]} -eq 0 ] && return 1
+  [ ${#matches[@]} -gt 1 ] && warn "multiple payloads named '$name'; using ${matches[0]}"
+  printf '%s\n' "${matches[0]}"
+}
+
+# Render one payload (apply its overrides) into <out>. Sets RP_APPLIED/RP_MISSING.
+render_payload() {  # render_payload <src> <out> <name>
+  local src="$1" out="$2" name="$3" line find repl
+  RP_APPLIED=0; RP_MISSING=0
+  cp "$src" "$out"
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    case "$line" in
+      *' --> '*) : ;;
+      *) warn "  [$name] malformed override (need ' --> '): $line"; continue ;;
+    esac
+    find="${line%% --> *}"
+    repl="${line#* --> }"
+    if ! grep -qF -- "$find" "$out"; then
+      warn "  [$name] FIND not present, override SKIPPED: $find"
+      RP_MISSING=$((RP_MISSING + 1)); continue
+    fi
+    apply_override "$out" "$find" "$repl" > "$out.tmp" && mv "$out.tmp" "$out"
+    RP_APPLIED=$((RP_APPLIED + 1))
+  done < <(overrides_for "$name")
+}
+
+# ---- argument parsing ------------------------------------------------------
+CONFIG="$DEFAULT_CONFIG"
+DRY_RUN=0
+NO_OUI=0
+FORCE=0
+DO_INIT=0
+INIT_TARGET=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    --init)
+      DO_INIT=1
+      if [ $# -ge 2 ] && [ "${2#-}" = "$2" ]; then INIT_TARGET="$2"; shift; fi
+      ;;
+    --config)
+      [ $# -ge 2 ] || die "--config needs a FILE argument"
+      CONFIG="$2"; shift ;;
+    --dry-run) DRY_RUN=1 ;;
+    --no-oui)  NO_OUI=1 ;;
+    --force)   FORCE=1 ;;
+    *) die "unknown option: $1 (try --help)" ;;
+  esac
+  shift
+done
+
+# ---- --init: write a template and exit -------------------------------------
+if [ "$DO_INIT" -eq 1 ]; then
+  target="${INIT_TARGET:-$DEFAULT_CONFIG}"
+  if [ -e "$target" ] && [ "$FORCE" -ne 1 ]; then
+    die "$target already exists (use --force to overwrite)"
+  fi
+  template_config > "$target"
+  info "[ok] wrote template config: $target"
+  info "    edit it to choose payloads and overrides, then run: ./deploy-shark.sh"
+  exit 0
+fi
+
+# ---- preflight -------------------------------------------------------------
+[ -d "$PAYLOAD_LIBRARY" ] || die "payload library not found at $PAYLOAD_LIBRARY"
+[ -f "$CONFIG" ] || die "config not found: $CONFIG (create one with: ./deploy-shark.sh --init)"
+
+PAYLOADS=()
+while IFS= read -r p; do [ -n "$p" ] && PAYLOADS+=("$p"); done < <(list_payloads)
+[ ${#PAYLOADS[@]} -gt 0 ] || die "no payload sections in $CONFIG (add at least one [payload_name])"
+
+# Options from config.
+CFG_IP=$(get_option shark_ip || true)
+CFG_OUI=$(get_option install_oui_db || true)
+case "$(printf '%s' "${CFG_OUI:-yes}" | tr 'A-Z' 'a-z')" in
+  no|false|0|off) NO_OUI=1 ;;
+esac
+
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/shark-deploy.XXXXXX")
+trap 'rm -rf "$WORKDIR"' EXIT
+
+info "[*] Config : $CONFIG"
+info "[*] Source : $PAYLOAD_LIBRARY"
+info "[*] Payloads requested: ${#PAYLOADS[@]}"
+
+# ---- DRY RUN: render and report, touch nothing -----------------------------
+if [ "$DRY_RUN" -eq 1 ]; then
+  info "[*] DRY RUN - rendering only, no device contacted."
+  resolved=0
+  for name in "${PAYLOADS[@]}"; do
+    src=$(resolve_payload "$name" || true)
+    if [ -z "$src" ]; then warn "  - $name: NOT FOUND under payloads/library/"; continue; fi
+    out="$WORKDIR/$name.payload.txt"
+    render_payload "$src" "$out" "$name"
+    info "  + $name (overrides applied: $RP_APPLIED, skipped: $RP_MISSING)"
+    resolved=$((resolved + 1))
+  done
+  info "[*] Rendered $resolved payload(s) into: $WORKDIR"
+  info "[*] OUI database would be: $([ "$NO_OUI" -eq 1 ] && echo skipped || echo installed)"
+  info "[ok] Dry run complete. Re-run without --dry-run to provision a device."
+  trap - EXIT          # keep rendered files around for inspection
+  exit 0
+fi
+
+# ---- prompts ---------------------------------------------------------------
+default_ip="${CFG_IP:-$DEFAULT_IP}"
+read -r -p "Shark IP [$default_ip]: " SHARK_IP
+SHARK_IP=${SHARK_IP:-$default_ip}
+read -r -s -p "Shark root password: " SHARK_PASS; echo
+[ -n "$SHARK_PASS" ] || die "no password entered"
+
+SSH_OPTS=(-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=8)
+
+# ---- auth wrapper: sshpass, else one shared SSH master (prompts once) -------
+if command -v sshpass >/dev/null 2>&1; then
+  RSH() { sshpass -p "$SHARK_PASS" ssh "${SSH_OPTS[@]}" "root@$SHARK_IP" "$@"; }
+  RCP() { sshpass -p "$SHARK_PASS" scp "${SSH_OPTS[@]}" "$@"; }
+else
+  info "[i] sshpass not found - opening one SSH connection (enter the password once when asked)."
+  CTRL="${TMPDIR:-/tmp}/shark-deploy-$$.ctl"
+  ssh "${SSH_OPTS[@]}" -M -S "$CTRL" -o ControlPersist=600 -fN "root@$SHARK_IP"
+  trap 'ssh -S "$CTRL" -O exit "root@$SHARK_IP" 2>/dev/null || true; rm -rf "$WORKDIR"' EXIT
+  RSH() { ssh "${SSH_OPTS[@]}" -S "$CTRL" "root@$SHARK_IP" "$@"; }
+  RCP() { scp "${SSH_OPTS[@]}" -o ControlPath="$CTRL" "$@"; }
+fi
+
+info "[*] Target: root@$SHARK_IP"
+RSH 'echo "[ok] connected: $(cat /proc/sys/kernel/hostname 2>/dev/null || echo shark)"'
+
+# ---- push payloads (rendered, only payload.txt) ----------------------------
+info "[*] Pushing payloads to /root/library/my_payloads/ ..."
+count=0
+for name in "${PAYLOADS[@]}"; do
+  src=$(resolve_payload "$name" || true)
+  if [ -z "$src" ]; then warn "  - skip $name (not found under payloads/library/)"; continue; fi
+  out="$WORKDIR/$name.payload.txt"
+  render_payload "$src" "$out" "$name"
+  RSH "mkdir -p /root/library/my_payloads/$name"
+  RCP "$out" "root@$SHARK_IP:/root/library/my_payloads/$name/payload.txt"
+  info "  + $name (overrides: $RP_APPLIED applied, $RP_MISSING skipped)"
+  count=$((count + 1))
+done
+info "[*] Pushed $count payload(s)."
+
+# ---- nmap OUI database -----------------------------------------------------
+if [ "$NO_OUI" -eq 1 ]; then
+  info "[*] Skipping nmap OUI database (per config/--no-oui)."
+else
+  info "[*] Installing nmap MAC/OUI database..."
+  TMP_PREFIX="$WORKDIR/nmap-mac-prefixes"
+  curl -fL "$PREFIX_URL" -o "$TMP_PREFIX"
+  info "    downloaded $(wc -l < "$TMP_PREFIX" | tr -d ' ') OUI rows"
+  RCP "$TMP_PREFIX" "root@$SHARK_IP:/root/nmap-mac-prefixes"
+  RSH 'ln -sf /root/nmap-mac-prefixes /usr/share/nmap/nmap-mac-prefixes'
+fi
+
+# ---- verify ----------------------------------------------------------------
+info "[*] Verifying..."
+RSH '
+  echo "  payloads:"; ls -1 /root/library/my_payloads 2>/dev/null | sed "s/^/    /"
+  echo "  oui db:   $(ls -l /usr/share/nmap/nmap-mac-prefixes 2>/dev/null | sed "s/.* -> /-> /")"
+  echo "  oui rows: $(wc -l < /root/nmap-mac-prefixes 2>/dev/null | tr -d " ")"
+'
+info "[ok] $SHARK_IP provisioned. Browse Payloads on the device to run them."

--- a/tools/deploy-shark/shark.conf.example
+++ b/tools/deploy-shark/shark.conf.example
@@ -1,0 +1,40 @@
+# ============================================================================
+#  shark.conf - deploy configuration for deploy-shark.sh
+# ----------------------------------------------------------------------------
+#  Pick which payloads to load onto the Shark Jack Display, and optionally
+#  override config values inside each payload before it is pushed.
+#
+#  FORMAT
+#    [options]                         global settings (optional)
+#      shark_ip = 172.16.24.1          default device IP (password is prompted)
+#      install_oui_db = yes            install the nmap OUI database (yes/no)
+#
+#    [payload_name]                    one section per payload to load. The name
+#                                      is the payload's directory under
+#                                      payloads/library/<category>/.
+#      FIND --> REPLACE                optional. Literal find-and-replace applied
+#                                      to that payload's payload.txt before it is
+#                                      pushed. FIND must match the line EXACTLY
+#                                      (copy it from the payload's CONFIG block).
+#
+#  A payload section with no FIND --> REPLACE lines is loaded unchanged.
+#  Lines starting with # are comments. This file is gitignored: keep your real
+#  IPs / hostnames / secrets here.
+# ============================================================================
+
+[options]
+shark_ip = 172.16.24.1
+install_oui_db = yes
+
+# --- Load the port-ID beacon, unchanged ---
+[port_id_beacon]
+
+# --- Load jack_survey, pre-filled with the drop you expect ---
+[jack_survey]
+EXPECTED_SWITCH="" --> EXPECTED_SWITCH="MDF-SW-01"
+EXPECTED_VLAN="" --> EXPECTED_VLAN="20"
+
+# --- Load the remote debug bridge, pointed at your jump host ---
+[remote_debug_bridge]
+JUMP_HOST="X.X.X.X" --> JUMP_HOST="203.0.113.10"
+JUMP_USER="sharkdebug" --> JUMP_USER="bridge"


### PR DESCRIPTION
## Summary

Contributes 13 new Shark Jack Display payloads (12 recon, 1 general) plus a
host-side deploy helper. This is purely additive: none of these paths exist in
the current repo, so no existing files are modified.

All tested on firmware 1.0.1
- Most payloads were tested on a local router with mixed ethernet and wifi network spread across 3 VLANs
- Direct Host Profiler payload was tested against a Clockwork Pi UConsole and a Lenovo Thinkpad
- Remote Debug Bridge payload was tested using a GCE VM in GCP
- Deploy Shark script was tested on two SharkJackDisplay models on both 1.0.0 and 1.0.1. 
- Net Map Explorer artifacts can be visualized using dot or mmdc

### Added

| Path | Category | What it is |
| --- | --- | --- |
| `payloads/library/general/remote_debug_bridge/` | general / remote-access | Reverse SSH bridge: opens an outbound tunnel to a known host, providing remote access back into a Linux host on the affected network. |
| `payloads/library/recon/dhcp_dns_ad/` | recon | DHCP + DNS / AD Profiler: one-pass answer to "what kind of network is this?" (DHCP lease, DNS, Active Directory domain). |
| `payloads/library/recon/direct_host_profiler/` | recon | Fingerprints a single unknown device cabled directly to the Shark Jack (identity, services, OS hints). |
| `payloads/library/recon/full_recon/` | recon | Wired Network Recon + Loot: plug in, walk away, come back to a tidy on-device loot report. |
| `payloads/library/recon/jack_survey/` | recon | Jack Survey / Drop Validator: validates one wall jack (link, PoE, VLAN, DHCP, reachability). |
| `payloads/library/recon/net_map_exporter/` | recon | Discovers the local segment and exports a network map / diagram of the drop. |
| `payloads/library/recon/passive_listen/` | recon (passive) | Brings the link up, transmits almost nothing, and passively listens to characterize the segment. |
| `payloads/library/recon/poe_survey/` | recon (passive) | Passive PoE survey of a drop (class and power signaling). |
| `payloads/library/recon/port_id_beacon/` | recon (passive) | Passive cable-tracing beacon to trace an unknown wall jack back to its switchport. |
| `payloads/library/recon/posture_quickhits/` | recon / assessment | Security Posture Quick-Hits: sweeps live hosts for the findings that drive remediation (default-community SNMP, SMB enumeration). |
| `payloads/library/recon/risky_devices/` | recon / assessment | Rogue / Risky Device Detector: flags devices that don't belong or that nobody remembers plugging in. |
| `payloads/library/recon/segmentation_egress/` | recon / assessment | Segmentation + Egress Check: characterizes what a single drop is allowed to reach, internally and out to the internet. |
| `payloads/library/recon/voice_camera_discovery/` | recon (passive) | Passive discovery of VoIP phones and IP cameras (voice / camera VLAN signaling). |
| `tools/deploy-shark/` | tooling | Host-side helper (`deploy-shark.sh`, `README.md`, `shark.conf.example`) to push payloads onto the device over SSH. |

Each payload ships with both a `payload.txt` and a `README.md`.

### Changed

None. No existing files in this repository are modified by this PR.

### New supporting files (justification)

- **`tools/` directory for `deploy-shark`:** this script runs on the operator's workstation, not on the Shark, so it does not belong under `payloads/library/`; a top-level `tools/` keeps host-side helpers cleanly separated from device payloads.
- **`tools/deploy-shark/.gitignore`:** ignores the operator's real `shark.conf` (site-specific IPs, hostnames, and overrides) so only the tracked `shark.conf.example` template ships, and no environment-specific data is ever committed.
- **Root `.gitignore`:** ignores `.DS_Store` so macOS contributors don't accidentally commit Finder metadata into the repository.